### PR TITLE
fast-patching library to be compatible with colab and environments where latest transformers, tensorflow is installed. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ We recommend using [flash attention](https://github.com/Dao-AILab/flash-attentio
 ```bash
 pip install flash-attn --no-build-isolation
 ```
+##### Note: Those who are using Google colab or latest versions of tensorflow and numpy will encounter an error in the library of transformers due to a tensorflow specific error. It can be avoided if you install (downgrade your tensorflow and numpy versions slightly)
+
+```Bash
+tensorflow==2.17.1
+numpy==2.1.0
+```
 
 ## Usage
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+tensorflow==2.17.1
+numpy==2.1.0


### PR DESCRIPTION
I tried installing the library and running some experiments on Google colab. Unfortunately, it was breaking due to recent tensorflow changes and numpy changes. HF did not account them before pushing latest transformers version and older is not compatible with this library since meta-llama class failed error happens with them. 

A fast-patch for this will be downgrading tensorflow and numpy versions slightly. It's not a KVPress specific error as it is happening due to transformers library. Particularly for this line:

```Python
from transformers.pipelines import PIPELINE_REGISTRY
```

I have added a requirements.txt file in the main-dir so that others don't face this error. I will also open an issue on HF as well. 

Collab I experimented with: https://colab.research.google.com/drive/1482Nc7IfE-s5sl7dBjEbWfOjz59QFA1l?usp=sharing