### PR TITLE
add support for QuantizedCache

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ pipe(..., cache=cache)
 By default, the `DynamicCache` is used (no quantization). 
 
 > [!IMPORTANT]  
-> To use the `QuantizedCache`, you might need to install additional packages, such as optimum-quanto. See also [this issue](https://github.com/huggingface/transformers/issues/34848).
+> To use the `QuantizedCache`, you need to install additional dependencies (e.g. `pip install optimum-quanto==0.2.4`, see also [this issue](https://github.com/huggingface/transformers/issues/34848)).
 
 
 ## FAQ

--- a/README.md
+++ b/README.md
@@ -75,10 +75,11 @@ We support KV cache quantization through the transformers `QuantizedCache` class
 
 ```python
 from transformers import QuantizedCacheConfig, QuantoQuantizedCache
+
 config = QuantizedCacheConfig(nbits=4)
 cache = QuantoQuantizedCache(config)
 
-pipe(...., cache=cache)
+pipe(..., cache=cache)
 ```
 
 By default, the `DynamicCache` is used (no quantization). 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,24 @@ _Average performance on the RULER dataset with 4k context length and Loogle Shor
 
 Please refer to the [evaluation](evaluation/README.md) directory for more details and results.
 
+## KV cache quantization
+
+We support KV cache quantization through the transformers `QuantizedCache` class (see [HF blog post](https://huggingface.co/blog/kv-cache-quantization#how-to-use-quantized-kv-cache-in-%F0%9F%A4%97-transformers)). To use it, simply pass a cache object to your pipeline:
+
+```python
+from transformers import QuantizedCacheConfig, QuantoQuantizedCache
+config = QuantizedCacheConfig(nbits=4)
+cache = QuantoQuantizedCache(config)
+
+pipe(...., cache=cache)
+```
+
+By default, the `DynamicCache` is used (no quantization). 
+
+> [!IMPORTANT]  
+> To use the `QuantizedCache`, you might need to install additional packages, such as optimum-quanto. See also [this issue](https://github.com/huggingface/transformers/issues/34848).
+
+
 ## FAQ
 
 <details><summary> 
@@ -162,10 +180,3 @@ Check the [demo notebook](notebooks/per_layer_compression_demo.ipynb) for more d
 </details>
 
 <details><summary> 
-
-### Is quantization supported ?
-</summary>
-
-We don't support quantization of the KV cache yet. Quantization can achieve up to 4x compression moving from (b)float16 to int4 and we believe it is orthogonal to the KV cache pruning strategies proposed in this repository.
-
-</details>

--- a/kvpress/presses/base_press.py
+++ b/kvpress/presses/base_press.py
@@ -15,11 +15,18 @@
 
 import logging
 from contextlib import contextmanager
-from typing import Dict, Generator
+from typing import Generator
 
 import torch
 from torch import nn
-from transformers import LlamaForCausalLM, MistralForCausalLM, Phi3ForCausalLM, PreTrainedModel, Qwen2ForCausalLM
+from transformers import (
+    LlamaForCausalLM,
+    MistralForCausalLM,
+    Phi3ForCausalLM,
+    PreTrainedModel,
+    Qwen2ForCausalLM,
+    QuantizedCache,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -69,7 +76,7 @@ class BasePress:
         """
         raise NotImplementedError
 
-    def forward_hook(self, module: nn.Module, input: list[torch.Tensor], kwargs: Dict, output: list):
+    def forward_hook(self, module: nn.Module, input: list[torch.Tensor], kwargs: dict, output: list):
         """Cache compression hook called after the forward pass of a decoder layer.
         The hook is applied only during the pre-filling phase if there is some pruning ratio.
         The current implementation only allows to remove a constant number of KV pairs.
@@ -103,8 +110,12 @@ class BasePress:
         if (self.compression_ratio == 0) or (cache.seen_tokens > q_len):
             return output
 
-        keys = cache.key_cache[module.layer_idx]
-        values = cache.value_cache[module.layer_idx]
+        if isinstance(cache, QuantizedCache):
+            keys = cache._dequantize(cache._quantized_key_cache[module.layer_idx])
+            values = cache._dequantize(cache._quantized_value_cache[module.layer_idx])
+        else:
+            keys = cache.key_cache[module.layer_idx]
+            values = cache.value_cache[module.layer_idx]
 
         with torch.no_grad():
             scores = self.score(module, hidden_states, keys, values, attentions, kwargs)
@@ -115,8 +126,14 @@ class BasePress:
         indices = indices.unsqueeze(-1).expand(-1, -1, -1, module.head_dim)
 
         # Update cache
-        cache.key_cache[module.layer_idx] = keys.gather(2, indices)
-        cache.value_cache[module.layer_idx] = values.gather(2, indices)
+        keys = keys.gather(2, indices).contiguous()
+        values = values.gather(2, indices).contiguous()
+        if isinstance(cache, QuantizedCache):
+            cache._quantized_key_cache[module.layer_idx] = cache._quantize(keys, axis=cache.axis_key)
+            cache._quantized_value_cache[module.layer_idx] = cache._quantize(values, axis=cache.axis_value)
+        else:
+            cache.key_cache[module.layer_idx] = keys
+            cache.value_cache[module.layer_idx] = values
 
         return output
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "kvpress"
 authors = ["Simon Jegou", "Maximilian Jeblick", "Jiwei Liu", "David Austin"]
 description = "Efficiently compress the KV cache of any pretrained transformer"
-version = "0.0.1"
+version = "0.0.2"
 readme = "README.md"
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
Transformers support KV cache quantization through the `QuantizedCache` class (see [their blog post](https://huggingface.co/blog/kv-cache-quantization#how-to-use-quantized-kv-cache-in-%F0%9F%A4%97-transformers)). I propose to update `BasePress` and `pipeline.py` to support it. 

Note that it implies to add several installations I did not include in `pyproject.toml` following their philosophy of not install additional kernels. I noticed issues during installation as mentioned [here](https://github.com/huggingface/transformers/issues/34848).