### PR TITLE
Fix pipeline for sdpa

### DIFF
--- a/kvpress/pipeline.py
+++ b/kvpress/pipeline.py
@@ -170,7 +170,7 @@ class KVPressTextGenerationPipeline(Pipeline):
             self.model(
                 input_ids=context_ids,
                 past_key_values=cache,
-                output_attentions=self.output_attentions,
+                output_attentions=self.output_attentions(press),
                 num_logits_to_keep=1,
             )
 

--- a/kvpress/pipeline.py
+++ b/kvpress/pipeline.py
@@ -12,7 +12,6 @@ from transformers.pipelines import PIPELINE_REGISTRY
 from transformers.pipelines.base import GenericTensor
 
 from kvpress.presses.base_press import BasePress
-from kvpress.presses.composed_press import ComposedPress
 from kvpress.presses.key_rerotation_press import KeyRerotationPress
 from kvpress.presses.observed_attention_press import ObservedAttentionPress
 from kvpress.presses.per_layer_compression_press import PerLayerCompressionPress
@@ -195,10 +194,6 @@ class KVPressTextGenerationPipeline(Pipeline):
             return True
         if isinstance(press, (KeyRerotationPress, PerLayerCompressionPress)) and isinstance(
             press.press, ObservedAttentionPress
-        ):
-            return True
-        if isinstance(press, ComposedPress) and any(
-            isinstance(sub_press, ObservedAttentionPress) for sub_press in press.presses
         ):
             return True
         return False

--- a/kvpress/presses/composed_press.py
+++ b/kvpress/presses/composed_press.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 
 from kvpress.presses.base_press import BasePress
+from kvpress.presses.observed_attention_press import ObservedAttentionPress
 
 
 @dataclass
@@ -13,6 +14,9 @@ class ComposedPress(BasePress):
 
     def __post_init__(self):
         self.compression_ratio = None
+        assert not any(
+            isinstance(press, ObservedAttentionPress) for press in self.presses
+        ), "ComposedPress cannot contains ObservedAttentionPress because attentions pruning is not handled"
 
     def forward_hook(self, module, input, kwargs, output):
         self.compression_ratio = 1.0

--- a/kvpress/presses/observed_attention_press.py
+++ b/kvpress/presses/observed_attention_press.py
@@ -27,8 +27,8 @@ class ObservedAttentionPress(ScorerPress):
     def __post_init__(self):
         if not self.output_attentions:
             logger.warning(
-                "Model will not return attentions in its output to save memory. Please use DefaultPruner if"
-                " attentions are needed in the output."
+                "Model will not return attentions in its output to save memory. "
+                "Set output_attentions=True if attentions are needed in the output."
             )
         super().__post_init__()
 


### PR DESCRIPTION
There was a missing argument l173 in pipeline.py:

```python
output_attentions=self.output_attentions,
```

instead of 

```python
output_attentions=self.output_attentions(press),
```

This was not visible when using `attn_implementation="flash_attention_2"` but when using `attn_implementation="sdpa"` the model defaulted back to `attn_implementation="sdpa"`.

I also excluded `ObservedAttentionPress` from the `ComposedPress` because we do not prune the attentions matrices. If `ObservedAttentionPress` comes after another press, there is a mismatch between the attentions matrices and the keys and values matrices.

