### PR TITLE
Fix distributed inference

### DIFF
--- a/kvpress/presses/expected_attention_press.py
+++ b/kvpress/presses/expected_attention_press.py
@@ -76,7 +76,7 @@ class ExpectedAttentionPress(ScorerPress):
         R = cos.unsqueeze(1) * Id + sin.unsqueeze(1) * P
 
         # Apply average rotation to the mean and covariance
-        R = R.mean(dim=0)
+        R = R.mean(dim=0).to(mu.device)
         mu = torch.matmul(mu, R.T)
         if self.use_covariance:
             cov = torch.matmul(R, torch.matmul(cov, R.T))


### PR DESCRIPTION
The `device_map="auto"` option in the pipeline failed for `ExpectedAttentionPress` because in every layer, this press uses the rotary embedding layer (to re-do the same computations btw) which is stucked in `cuda:0`.

I checked that this was the only press with an issue by running `test_presses.py` and temporarily replacing the the `unit_test_model` by llama3 8b on 2 GPUs.