### PR TITLE
add ChunkKV

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,4 +160,20 @@ with torch.no_grad(), press(model):
     print(model(inputs).past_key_values[0][0].shape)
     # torch.Size([3, 8, 3, 128])
 ```
-</
+</details>
+
+<details><summary> 
+
+### Why not using model.generate ? 
+</summary>
+
+In fact you can use `model.generate` with a press by using the press as a context manager:
+
+```python
+with press(model):
+    outputs = model.generate(inputs)
+```
+
+However, the `generate` method does not allow to exclude the question from the compression, which would artificially favors methods such as SnapKV. Ideally, we want a compression method that works whatever comes after the context (_e.g._ for use cases such as chat or document question answering). Finally the `generate` method does not allow to provide generation for multiple questions at once.
+
+</details>

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Finally we provide wrapper presses that can be combined with other presses:
 - `PerLayerCompressionPress` ([source](kvpress/presses/per_layer_compression_press.py)): compress each layer with a different compression ratio (experimental)
 - `ComposedPress` ([source](kvpress/presses/composed_press.py)): compose multiple presses together by chaining their forward hooks
 - `KeyRerotationPress` ([source](kvpress/presses/key_rerotation_press.py)): rerotate pruned keys to have continuous RoPE embeddings
-- `ChunkPress` ([source](kvpress/presses/chunk_press.py), [paper](https://direct.mit.edu/tacl/article/doi/10.1162/tacl_a_00716/125280)): compress the KV cache on each sequence chunk separately. This can yield to more uniform compression across long sequences
+- `ChunkPress` ([source](kvpress/presses/chunk_press.py), [paper](https://direct.mit.edu/tacl/article/doi/10.1162/tacl_a_00716/125280), [ChunkKV](https://arxiv.org/abs/2502.00299)): compress the KV cache on each sequence chunk separately. This can yield to more uniform compression across long sequences. Passing `global_scoring=True` will use ChunkKV compression as proposed in the [ChunkKV paper](https://arxiv.org/abs/2502.00299).
 - `CriticalKVPress` and `CriticalAdaKVPress` ([source](kvpress/presses/criticalkv_press.py), [paper](https://arxiv.org/abs/2502.03805)): refine the scores using the L1 norm of Wo @ values, coupled with a two-stage selection.
 
 For a detailed list of existing KV cache compression methods, check [Awesome-KV-Cache-Compression](https://github.com/October2001/Awesome-KV-Cache-Compression) or [Awesome-LLM-Compression](https://github.com/HuangOwen/Awesome-LLM-Compression?tab=readme-ov-file#kv-cache-compression)

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Finally we provide wrapper presses that can be combined with other presses:
 - `PerLayerCompressionPress` ([source](kvpress/presses/per_layer_compression_press.py)): compress each layer with a different compression ratio (experimental)
 - `ComposedPress` ([source](kvpress/presses/composed_press.py)): compose multiple presses together by chaining their forward hooks
 - `KeyRerotationPress` ([source](kvpress/presses/key_rerotation_press.py)): rerotate pruned keys to have continuous RoPE embeddings
-- `ChunkKVPress` ([source](kvpress/presses/chunkkv_press.py), [paper](https://arxiv.org/abs/2502.00299)): implements the ChunkKV compression method that selects whole chunks based on their importance scores. This approach differs from ChunkPress by maintaining chunk-level granularity during selection, which helps preserve local attention patterns. The method is particularly effective for long sequences where maintaining contextual coherence is important.
+- `ChunkKVPress` ([source](kvpress/presses/chunkkv_press.py), [paper](https://arxiv.org/abs/2502.00299)): compresses by selecting important chunks, preserving semantic coherence
 - `ChunkPress` ([source](kvpress/presses/chunk_press.py), [paper](https://direct.mit.edu/tacl/article/doi/10.1162/tacl_a_00716/125280)): compress the KV cache on each sequence chunk separately. This can yield to more uniform compression across long sequences
 - `CriticalKVPress` and `CriticalAdaKVPress` ([source](kvpress/presses/criticalkv_press.py), [paper](https://arxiv.org/abs/2502.03805)): refine the scores using the L1 norm of Wo @ values, coupled with a two-stage selection.
 

--- a/evaluation/evaluate.py
+++ b/evaluation/evaluate.py
@@ -29,6 +29,7 @@ from kvpress import (
     ThinKPress,
     TOVAPress,
     DuoAttentionPress,
+    ChunkPress
 )
 
 logger = logging.getLogger(__name__)
@@ -64,6 +65,7 @@ PRESS_DICT = {
     "think": ThinKPress(),
     "tova": TOVAPress(),
     "duo_attention": DuoAttentionPress(),
+    "chunkkv": ChunkPress(press=SnapKVPress(), global_scoring=True, chunk_length=20),
 }
 
 

--- a/evaluation/evaluate.py
+++ b/evaluation/evaluate.py
@@ -29,7 +29,7 @@ from kvpress import (
     ThinKPress,
     TOVAPress,
     DuoAttentionPress,
-    ChunkPress
+    ChunkKVPress
 )
 
 logger = logging.getLogger(__name__)
@@ -65,7 +65,7 @@ PRESS_DICT = {
     "think": ThinKPress(),
     "tova": TOVAPress(),
     "duo_attention": DuoAttentionPress(),
-    "chunkkv": ChunkPress(press=SnapKVPress(), global_scoring=True, chunk_length=20),
+    "chunkkv": ChunkKVPress(press=SnapKVPress(), chunk_length=20),
 }
 
 

--- a/evaluation/evaluate.py
+++ b/evaluation/evaluate.py
@@ -17,9 +17,11 @@ from transformers import pipeline
 from zero_scrolls.calculate_metrics import calculate_metrics as zero_scrolls_scorer
 
 from kvpress import (
-    CriticalKVPress,
-    CriticalAdaKVPress,
     AdaKVPress,
+    ChunkKVPress,
+    CriticalAdaKVPress,
+    CriticalKVPress,
+    DuoAttentionPress,
     ExpectedAttentionPress,
     KnormPress,
     ObservedAttentionPress,
@@ -28,8 +30,6 @@ from kvpress import (
     StreamingLLMPress,
     ThinKPress,
     TOVAPress,
-    DuoAttentionPress,
-    ChunkKVPress
 )
 
 logger = logging.getLogger(__name__)

--- a/kvpress/__init__.py
+++ b/kvpress/__init__.py
@@ -9,6 +9,8 @@ from kvpress.presses.base_press import BasePress
 from kvpress.presses.chunk_press import ChunkPress
 from kvpress.presses.chunkkv_press import ChunkKVPress
 from kvpress.presses.composed_press import ComposedPress
+from kvpress.presses.criticalkv_press import CriticalAdaKVPress, CriticalKVPress
+from kvpress.presses.duo_attention_press import DuoAttentionPress
 from kvpress.presses.expected_attention_press import ExpectedAttentionPress
 from kvpress.presses.key_rerotation_press import KeyRerotationPress
 from kvpress.presses.knorm_press import KnormPress
@@ -21,8 +23,6 @@ from kvpress.presses.snapkv_press import SnapKVPress
 from kvpress.presses.streaming_llm_press import StreamingLLMPress
 from kvpress.presses.think_press import ThinKPress
 from kvpress.presses.tova_press import TOVAPress
-from kvpress.presses.criticalkv_press import CriticalKVPress, CriticalAdaKVPress
-from kvpress.presses.duo_attention_press import DuoAttentionPress
 
 # Patch the attention functions to support head-wise compression
 patch_attention_functions()

--- a/kvpress/__init__.py
+++ b/kvpress/__init__.py
@@ -7,6 +7,7 @@ from kvpress.pipeline import KVPressTextGenerationPipeline
 from kvpress.presses.adakv_press import AdaKVPress
 from kvpress.presses.base_press import BasePress
 from kvpress.presses.chunk_press import ChunkPress
+from kvpress.presses.chunkkv_press import ChunkKVPress
 from kvpress.presses.composed_press import ComposedPress
 from kvpress.presses.expected_attention_press import ExpectedAttentionPress
 from kvpress.presses.key_rerotation_press import KeyRerotationPress
@@ -47,4 +48,5 @@ __all__ = [
     "KeyRerotationPress",
     "ChunkPress",
     "DuoAttentionPress",
+    "ChunkKVPress",
 ]

--- a/kvpress/presses/chunk_press.py
+++ b/kvpress/presses/chunk_press.py
@@ -50,7 +50,6 @@ class ChunkPress(BasePress):
         assert attentions is None, "ChunkPress does not support attentions."
 
         kv_len = keys.shape[2]
-
         indices = []
         for i in range(0, kv_len, self.chunk_length):
             chunk_scores = self.press.score(

--- a/kvpress/presses/chunk_press.py
+++ b/kvpress/presses/chunk_press.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass
 
 import torch
 from torch import nn
-import torch.nn.functional as F
 
 from kvpress.presses.base_press import BasePress
 from kvpress.presses.scorer_press import ScorerPress
@@ -15,21 +14,14 @@ from kvpress.presses.scorer_press import ScorerPress
 class ChunkPress(BasePress):
     """
     Wrapper class for any ScorerPress.
-    When global_scoring=False (default):
-        Chunks keys and values into chunks of size chunk_length and compresses each chunk separately.
-        This ensures that the context is compressed uniformly across the entire context.
-        This method was proposed in FINCH: Prompt-guided Key-Value Cache Compression for Large Language Models
-        https://direct.mit.edu/tacl/article/doi/10.1162/tacl_a_00716/125280
-    When global_scoring=True:
-        First calculates global scores using the ScorerPress,
-        then selects tokens chunk by chunk based on these global scores.
-        This method was proposed in ChunkKV: Semantic-Preserving KV Cache Compression for Efficient Long-Context LLM Inference
-        https://arxiv.org/abs/2502.00299
+    Chunks keys and values into chunks of size chunk_length and compresses each chunk separately.
+    This ensures that the context is compressed uniformly across the entire context.
+    This method was proposed in FINCH: Prompt-guided Key-Value Cache Compression for Large Language Models
+    https://direct.mit.edu/tacl/article/doi/10.1162/tacl_a_00716/125280
     """
 
     press: ScorerPress
-    chunk_length: int = 20
-    global_scoring: bool = False  # New parameter to control whether to use global scoring
+    chunk_length: int = 1024
 
     def __post_init__(self):
         assert isinstance(self.press, ScorerPress), "ChunkPress requires a ScorerPress as input"
@@ -58,80 +50,21 @@ class ChunkPress(BasePress):
         assert attentions is None, "ChunkPress does not support attentions."
 
         kv_len = keys.shape[2]
-        indices = []
 
-        if self.global_scoring:
-            # 1. Calculate global scores first
-            global_scores = self.press.score(
+        indices = []
+        for i in range(0, kv_len, self.chunk_length):
+            chunk_scores = self.press.score(
                 module,
-                hidden_states,
-                keys,
-                values,
+                hidden_states[:, i : i + self.chunk_length],
+                keys[:, :, i : i + self.chunk_length],
+                values[:, :, i : i + self.chunk_length],
                 attentions,
                 kwargs,
             )
-            
-            # 2. Calculate actual number of complete chunks and remaining tokens
-            num_complete_chunks = kv_len // self.chunk_length
-            remaining_tokens = kv_len % self.chunk_length
-            
-            # Reshape complete chunks for score calculation
-            if num_complete_chunks > 0:
-                main_scores = global_scores[..., :num_complete_chunks * self.chunk_length]
-                main_chunk_scores = main_scores.sum(dim=1).view(-1, num_complete_chunks, self.chunk_length)
-                main_chunk_scores = main_chunk_scores.mean(dim=-1)
-            else:
-                main_chunk_scores = torch.empty((global_scores.shape[0], 0), device=global_scores.device)
-            
-            # Handle remaining tokens if any
-            if remaining_tokens > 0:
-                remaining_scores = global_scores[..., -remaining_tokens:]
-                remaining_chunk_score = remaining_scores.sum(dim=1).mean(dim=-1, keepdim=True)
-                chunk_scores = torch.cat([main_chunk_scores, remaining_chunk_score], dim=-1)
-            else:
-                chunk_scores = main_chunk_scores
-            
-            # 3. Calculate number of chunks to keep
-            n_chunks_kept = max(1, int((num_complete_chunks + (remaining_tokens > 0)) * (1 - self.press.compression_ratio)))
-            top_chunks = chunk_scores.topk(n_chunks_kept, dim=-1)
-            
-            # 4. Create indices for selected chunks
-            indices = []
-            for chunk_idx in top_chunks.indices[0]:
-                if chunk_idx < num_complete_chunks:
-                    # For complete chunks
-                    start_idx = chunk_idx * self.chunk_length
-                    chunk_indices = torch.arange(start_idx, start_idx + self.chunk_length, 
-                                              device=keys.device)
-                else:
-                    # For the remaining partial chunk
-                    chunk_indices = torch.arange(num_complete_chunks * self.chunk_length, kv_len,
-                                              device=keys.device)
-                indices.append(chunk_indices)
-            
-            indices = torch.cat(indices).sort()[0]
-            indices = indices.view(1, 1, -1, 1).expand(keys.shape[0], keys.shape[1], -1, module.head_dim)
-            
-            # 5. Use gather to collect selected keys and values
-            keys = keys.gather(2, indices).contiguous()
-            values = values.gather(2, indices).contiguous()
-
-            return keys, values
-        else:
-            # Original method: calculate scores chunk by chunk
-            for i in range(0, kv_len, self.chunk_length):
-                chunk_scores = self.press.score(
-                    module,
-                    hidden_states[:, i : i + self.chunk_length],
-                    keys[:, :, i : i + self.chunk_length],
-                    values[:, :, i : i + self.chunk_length],
-                    attentions,
-                    kwargs,
-                )
-                chunk_length = keys[:, :, i : i + self.chunk_length].shape[2]
-                n_kept = max(1, int(chunk_length * (1 - self.press.compression_ratio)))
-                chunk_indices = i + chunk_scores.topk(n_kept, dim=-1).indices
-                indices.append(chunk_indices)
+            chunk_length = keys[:, :, i : i + self.chunk_length].shape[2]
+            n_kept = max(1, int(chunk_length * (1 - self.press.compression_ratio)))
+            chunk_indices = i + chunk_scores.topk(n_kept, dim=-1).indices
+            indices.append(chunk_indices)
 
         indices = torch.cat(indices, dim=-1)
         indices = indices.unsqueeze(-1).expand(-1, -1, -1, module.head_dim)

--- a/kvpress/presses/chunk_press.py
+++ b/kvpress/presses/chunk_press.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 
 import torch
 from torch import nn
+import torch.nn.functional as F
 
 from kvpress.presses.base_press import BasePress
 from kvpress.presses.scorer_press import ScorerPress
@@ -14,14 +15,21 @@ from kvpress.presses.scorer_press import ScorerPress
 class ChunkPress(BasePress):
     """
     Wrapper class for any ScorerPress.
-    Chunks keys and values into chunks of size chunk_length and compresses each chunk separately.
-    This ensures that the context is compressed uniformly across the entire context.
-    This method was proposed in FINCH: Prompt-guided Key-Value Cache Compression for Large Language Models
-    https://direct.mit.edu/tacl/article/doi/10.1162/tacl_a_00716/125280
+    When global_scoring=False (default):
+        Chunks keys and values into chunks of size chunk_length and compresses each chunk separately.
+        This ensures that the context is compressed uniformly across the entire context.
+        This method was proposed in FINCH: Prompt-guided Key-Value Cache Compression for Large Language Models
+        https://direct.mit.edu/tacl/article/doi/10.1162/tacl_a_00716/125280
+    When global_scoring=True:
+        First calculates global scores using the ScorerPress,
+        then selects tokens chunk by chunk based on these global scores.
+        This method was proposed in ChunkKV: Semantic-Preserving KV Cache Compression for Efficient Long-Context LLM Inference
+        https://arxiv.org/abs/2502.00299
     """
 
     press: ScorerPress
-    chunk_length: int = 1024
+    chunk_length: int = 20
+    global_scoring: bool = False  # New parameter to control whether to use global scoring
 
     def __post_init__(self):
         assert isinstance(self.press, ScorerPress), "ChunkPress requires a ScorerPress as input"
@@ -50,21 +58,80 @@ class ChunkPress(BasePress):
         assert attentions is None, "ChunkPress does not support attentions."
 
         kv_len = keys.shape[2]
-
         indices = []
-        for i in range(0, kv_len, self.chunk_length):
-            chunk_scores = self.press.score(
+
+        if self.global_scoring:
+            # 1. Calculate global scores first
+            global_scores = self.press.score(
                 module,
-                hidden_states[:, i : i + self.chunk_length],
-                keys[:, :, i : i + self.chunk_length],
-                values[:, :, i : i + self.chunk_length],
+                hidden_states,
+                keys,
+                values,
                 attentions,
                 kwargs,
             )
-            chunk_length = keys[:, :, i : i + self.chunk_length].shape[2]
-            n_kept = max(1, int(chunk_length * (1 - self.press.compression_ratio)))
-            chunk_indices = i + chunk_scores.topk(n_kept, dim=-1).indices
-            indices.append(chunk_indices)
+            
+            # 2. Calculate actual number of complete chunks and remaining tokens
+            num_complete_chunks = kv_len // self.chunk_length
+            remaining_tokens = kv_len % self.chunk_length
+            
+            # Reshape complete chunks for score calculation
+            if num_complete_chunks > 0:
+                main_scores = global_scores[..., :num_complete_chunks * self.chunk_length]
+                main_chunk_scores = main_scores.sum(dim=1).view(-1, num_complete_chunks, self.chunk_length)
+                main_chunk_scores = main_chunk_scores.mean(dim=-1)
+            else:
+                main_chunk_scores = torch.empty((global_scores.shape[0], 0), device=global_scores.device)
+            
+            # Handle remaining tokens if any
+            if remaining_tokens > 0:
+                remaining_scores = global_scores[..., -remaining_tokens:]
+                remaining_chunk_score = remaining_scores.sum(dim=1).mean(dim=-1, keepdim=True)
+                chunk_scores = torch.cat([main_chunk_scores, remaining_chunk_score], dim=-1)
+            else:
+                chunk_scores = main_chunk_scores
+            
+            # 3. Calculate number of chunks to keep
+            n_chunks_kept = max(1, int((num_complete_chunks + (remaining_tokens > 0)) * (1 - self.press.compression_ratio)))
+            top_chunks = chunk_scores.topk(n_chunks_kept, dim=-1)
+            
+            # 4. Create indices for selected chunks
+            indices = []
+            for chunk_idx in top_chunks.indices[0]:
+                if chunk_idx < num_complete_chunks:
+                    # For complete chunks
+                    start_idx = chunk_idx * self.chunk_length
+                    chunk_indices = torch.arange(start_idx, start_idx + self.chunk_length, 
+                                              device=keys.device)
+                else:
+                    # For the remaining partial chunk
+                    chunk_indices = torch.arange(num_complete_chunks * self.chunk_length, kv_len,
+                                              device=keys.device)
+                indices.append(chunk_indices)
+            
+            indices = torch.cat(indices).sort()[0]
+            indices = indices.view(1, 1, -1, 1).expand(keys.shape[0], keys.shape[1], -1, module.head_dim)
+            
+            # 5. Use gather to collect selected keys and values
+            keys = keys.gather(2, indices).contiguous()
+            values = values.gather(2, indices).contiguous()
+
+            return keys, values
+        else:
+            # Original method: calculate scores chunk by chunk
+            for i in range(0, kv_len, self.chunk_length):
+                chunk_scores = self.press.score(
+                    module,
+                    hidden_states[:, i : i + self.chunk_length],
+                    keys[:, :, i : i + self.chunk_length],
+                    values[:, :, i : i + self.chunk_length],
+                    attentions,
+                    kwargs,
+                )
+                chunk_length = keys[:, :, i : i + self.chunk_length].shape[2]
+                n_kept = max(1, int(chunk_length * (1 - self.press.compression_ratio)))
+                chunk_indices = i + chunk_scores.topk(n_kept, dim=-1).indices
+                indices.append(chunk_indices)
 
         indices = torch.cat(indices, dim=-1)
         indices = indices.unsqueeze(-1).expand(-1, -1, -1, module.head_dim)

--- a/kvpress/presses/chunkkv_press.py
+++ b/kvpress/presses/chunkkv_press.py
@@ -51,7 +51,7 @@ class ChunkKVPress(BasePress):
         assert attentions is None, "ChunkPress does not support attentions."
 
         kv_len = keys.shape[2]
-        
+
         # 1. Calculate global scores first
         global_scores = self.press.score(
             module,

--- a/kvpress/presses/chunkkv_press.py
+++ b/kvpress/presses/chunkkv_press.py
@@ -1,0 +1,112 @@
+# SPDX-FileCopyrightText: Copyright (c) 1993-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from dataclasses import dataclass
+
+import torch
+from torch import nn
+
+from kvpress.presses.base_press import BasePress
+from kvpress.presses.scorer_press import ScorerPress
+
+
+@dataclass
+class ChunkKVPress(BasePress):
+    """
+    Wrapper class for any ScorerPress.
+    First calculates global scores using the ScorerPress,
+    then selects tokens chunk by chunk based on these global scores.
+    This method was proposed in
+    ChunkKV: Semantic-Preserving KV Cache Compression for Efficient Long-Context LLM Inference
+    https://arxiv.org/abs/2502.00299
+    """
+
+    press: ScorerPress
+    chunk_length: int = 20
+
+    def __post_init__(self):
+        assert isinstance(self.press, ScorerPress), "ChunkKVPress requires a ScorerPress as input"
+
+    @property
+    def compression_ratio(self):
+        return self.press.compression_ratio
+
+    @compression_ratio.setter
+    def compression_ratio(self, value):
+        self.press.compression_ratio = value
+
+    def compress(
+        self,
+        module: nn.Module,
+        hidden_states: torch.Tensor,
+        keys: torch.Tensor,
+        values: torch.Tensor,
+        attentions: torch.Tensor,
+        kwargs: dict,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+
+        if self.press.compression_ratio == 0:
+            return keys, values
+
+        assert attentions is None, "ChunkPress does not support attentions."
+
+        kv_len = keys.shape[2]
+        
+        # 1. Calculate global scores first
+        global_scores = self.press.score(
+            module,
+            hidden_states,
+            keys,
+            values,
+            attentions,
+            kwargs,
+        )
+
+        # 2. Calculate actual number of complete chunks and remaining tokens
+        num_complete_chunks = kv_len // self.chunk_length
+        remaining_tokens = kv_len % self.chunk_length
+
+        # If we have no complete chunks, delegate to the underlying scorer press
+        if num_complete_chunks == 0:
+            return self.press.compress(module, hidden_states, keys, values, attentions, kwargs)
+
+        # Reshape complete chunks for score calculation
+        if num_complete_chunks > 0:
+            main_scores = global_scores[..., : num_complete_chunks * self.chunk_length]
+            main_chunk_scores = main_scores.sum(dim=1).view(-1, num_complete_chunks, self.chunk_length)
+            main_chunk_scores = main_chunk_scores.mean(dim=-1)
+        else:
+            main_chunk_scores = torch.empty((global_scores.shape[0], 0), device=global_scores.device)
+
+        # Handle remaining tokens if any
+        if remaining_tokens > 0:
+            remaining_scores = global_scores[..., -remaining_tokens:]
+            remaining_chunk_score = remaining_scores.sum(dim=1).mean(dim=-1, keepdim=True)
+            chunk_scores = torch.cat([main_chunk_scores, remaining_chunk_score], dim=-1)
+        else:
+            chunk_scores = main_chunk_scores
+
+        # 3. Calculate number of chunks to keep
+        n_chunks_kept = max(1, int((num_complete_chunks + (remaining_tokens > 0)) * (1 - self.press.compression_ratio)))
+        top_chunks = chunk_scores.topk(n_chunks_kept, dim=-1)
+
+        # 4. Create indices for selected chunks
+        indices = []
+        for chunk_idx in top_chunks.indices[0]:
+            if chunk_idx < num_complete_chunks:
+                # For complete chunks
+                start_idx = chunk_idx * self.chunk_length
+                chunk_indices = torch.arange(start_idx, start_idx + self.chunk_length, device=keys.device)
+            else:
+                # For the remaining partial chunk
+                chunk_indices = torch.arange(num_complete_chunks * self.chunk_length, kv_len, device=keys.device)
+            indices.append(chunk_indices)
+
+        indices = torch.cat(indices).sort()[0]
+        indices = indices.view(1, 1, -1, 1).expand(keys.shape[0], keys.shape[1], -1, module.head_dim)
+
+        # 5. Use gather to collect selected keys and values
+        keys = keys.gather(2, indices).contiguous()
+        values = values.gather(2, indices).contiguous()
+
+        return keys, values

--- a/kvpress/presses/criticalkv_press.py
+++ b/kvpress/presses/criticalkv_press.py
@@ -8,8 +8,8 @@ import torch
 from transformers.models.llama.modeling_llama import repeat_kv
 
 from kvpress.presses.base_press import BasePress
-from kvpress.presses.scorer_press import ScorerPress
 from kvpress.presses.expected_attention_press import ExpectedAttentionPress
+from kvpress.presses.scorer_press import ScorerPress
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +49,7 @@ class CriticalKVPress(ScorerPress):
         # Future kernel fusion optimization could eliminate this intermediate variables to enhance performance.
         head_WoV_norm_list = []
         for head in range(V.size(1)):
-            head_WoV = V[: , head, : , ...].matmul(Wo[head, ...].unsqueeze(0))
+            head_WoV = V[:, head, :, ...].matmul(Wo[head, ...].unsqueeze(0))
             head_WoV_norm = torch.norm(head_WoV, p=1, dim=-1)
             head_WoV_norm_list.append(head_WoV_norm)
 

--- a/kvpress/presses/duo_attention_press.py
+++ b/kvpress/presses/duo_attention_press.py
@@ -1,16 +1,15 @@
 # SPDX-FileCopyrightText: Copyright (c) 1993-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from io import StringIO
-from dataclasses import dataclass, field
 from contextlib import contextmanager
+from dataclasses import dataclass, field
+from io import StringIO
 
-import torch
-import requests  # type: ignore[import-untyped]
 import numpy as np
+import requests  # type: ignore[import-untyped]
+import torch
 
 from kvpress.presses.base_press import BasePress
-
 
 PATTERNS_DICT = {
     "togethercomputer/Llama-2-7B-32K-Instruct": "Llama-2-7B-32K-Instruct/lr%3D0.02-reg%3D0.05-ctx%3D1000_32000-multi_passkey10",  # noqa: E501

--- a/tests/default_presses.py
+++ b/tests/default_presses.py
@@ -4,6 +4,7 @@
 import numpy as np
 
 from kvpress import (
+    DuoAttentionPress,
     ExpectedAttentionPress,
     KnormPress,
     RandomPress,
@@ -12,7 +13,6 @@ from kvpress import (
     StreamingLLMPress,
     ThinKPress,
     TOVAPress,
-    DuoAttentionPress,
 )
 
 

--- a/tests/presses/test_duo_attention_press.py
+++ b/tests/presses/test_duo_attention_press.py
@@ -1,4 +1,4 @@
-from kvpress.presses.duo_attention_press import DuoAttentionPress, PATTERNS_DICT
+from kvpress.presses.duo_attention_press import PATTERNS_DICT, DuoAttentionPress
 
 
 def test_load_attention_pattern():

--- a/tests/presses/test_presses.py
+++ b/tests/presses/test_presses.py
@@ -8,12 +8,12 @@ from torch import nn
 from transformers import DynamicCache
 
 from kvpress import (
-    CriticalKVPress,
-    CriticalAdaKVPress,
     AdaKVPress,
     ChunkKVPress,
     ChunkPress,
     ComposedPress,
+    CriticalAdaKVPress,
+    CriticalKVPress,
     KeyRerotationPress,
     KnormPress,
     ObservedAttentionPress,
@@ -57,8 +57,10 @@ def test_chunkkv_press(unit_test_model):  # noqa: F811
 
 
 @pytest.mark.parametrize("press_dict", default_presses)
-@pytest.mark.parametrize("wrapper_press", [None, ComposedPress, KeyRerotationPress, AdaKVPress, ChunkPress,
-                                           CriticalKVPress, CriticalAdaKVPress])
+@pytest.mark.parametrize(
+    "wrapper_press",
+    [None, ComposedPress, KeyRerotationPress, AdaKVPress, ChunkPress, CriticalKVPress, CriticalAdaKVPress],
+)
 def test_presses_run(unit_test_model, press_dict, wrapper_press):  # noqa: F811
     cls = press_dict["cls"]
     for kwargs in press_dict["kwargs"]:

--- a/tests/presses/test_presses.py
+++ b/tests/presses/test_presses.py
@@ -11,12 +11,14 @@ from kvpress import (
     CriticalKVPress,
     CriticalAdaKVPress,
     AdaKVPress,
+    ChunkKVPress,
     ChunkPress,
     ComposedPress,
     KeyRerotationPress,
     KnormPress,
     ObservedAttentionPress,
     ScorerPress,
+    SnapKVPress,
     ThinKPress,
 )
 from tests.default_presses import default_presses
@@ -36,6 +38,17 @@ def test_chunk_press(unit_test_model):  # noqa: F811
     press = KnormPress(compression_ratio=0.5)
     for chunk_length in [2, 4, 8, 128]:
         composed_press = ChunkPress(press=press, chunk_length=chunk_length)
+        with composed_press(unit_test_model):
+            input_ids = torch.randint(0, 1024, (1, 256))
+            cache = DynamicCache()
+            unit_test_model(input_ids, past_key_values=cache).past_key_values
+            assert cache.get_seq_length() == 128
+
+
+def test_chunkkv_press(unit_test_model):  # noqa: F811
+    press = SnapKVPress(compression_ratio=0.5)
+    for chunk_length in [2, 4, 8, 128]:
+        composed_press = ChunkKVPress(press=press, chunk_length=chunk_length)
         with composed_press(unit_test_model):
             input_ids = torch.randint(0, 1024, (1, 256))
             cache = DynamicCache()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -9,7 +9,7 @@ import torch
 from transformers import AutoTokenizer, DynamicCache, QuantizedCacheConfig, QuantoQuantizedCache
 from transformers.utils import is_optimum_quanto_available
 
-from kvpress import ExpectedAttentionPress,ChunkPress,SnapKVPress
+from kvpress import ExpectedAttentionPress
 from kvpress.pipeline import KVPressTextGenerationPipeline
 from tests.fixtures import danube_500m_model  # noqa: F401
 from tests.fixtures import kv_press_danube_pipeline  # noqa: F401
@@ -21,7 +21,7 @@ def test_pipeline(kv_press_unit_test_pipeline, caplog):  # noqa: F811
     with caplog.at_level(logging.DEBUG):
         context = "This is a test article. It was written on 2022-01-01."
         questions = ["When was this article written?"]
-        press = ChunkPress(press=SnapKVPress(compression_ratio=0.4, window_size=3), chunk_length=5, global_scoring=True)
+        press = ExpectedAttentionPress(compression_ratio=0.4)
         answers = kv_press_unit_test_pipeline(context, questions=questions, press=press)["answers"]
 
     assert len(answers) == 1
@@ -35,7 +35,7 @@ def test_pipeline(kv_press_unit_test_pipeline, caplog):  # noqa: F811
 def test_pipeline_with_cache(kv_press_unit_test_pipeline, caplog):  # noqa: F811
     context = "This is a test article. It was written on 2022-01-01."
     questions = ["When was this article written?"]
-    press = ChunkPress(press=SnapKVPress(compression_ratio=0.4, window_size=3), chunk_length=5, global_scoring=True)
+    press = ExpectedAttentionPress(compression_ratio=0.4)
     cache = DynamicCache()
     answers = kv_press_unit_test_pipeline(context, questions=questions, press=press, cache=cache)["answers"]
 
@@ -47,7 +47,7 @@ def test_pipeline_with_cache(kv_press_unit_test_pipeline, caplog):  # noqa: F811
 def test_pipeline_single_or_no_question(kv_press_unit_test_pipeline, question, caplog):  # noqa: F811
     with caplog.at_level(logging.DEBUG):
         context = "This is a test article. It was written on 2022-01-01."
-        press = ChunkPress(press=SnapKVPress(compression_ratio=0.4, window_size=3), chunk_length=5, global_scoring=True)
+        press = ExpectedAttentionPress(compression_ratio=0.4)
         answer = kv_press_unit_test_pipeline(context, question=question, press=press)["answer"]
 
     assert isinstance(answer, str)
@@ -81,7 +81,7 @@ def test_pipeline_with_quantized_cache(kv_press_danube_pipeline, caplog):  # noq
     with caplog.at_level(logging.DEBUG):
         context = "This is a test article. It was written on 2022-01-01."
         questions = ["When was this article written?"]
-        press = ChunkPress(press=SnapKVPress(compression_ratio=0.4, window_size=3), chunk_length=5, global_scoring=True)
+        press = ExpectedAttentionPress(compression_ratio=0.4)
         config = QuantizedCacheConfig(nbits=4)
         cache = QuantoQuantizedCache(config)
         answers = kv_press_danube_pipeline(context, questions=questions, press=press, cache=cache)["answers"]
@@ -138,7 +138,7 @@ def generate_answer(model):
     model.to(device)
     context = "This is a test article. It was written on 2022-01-01."
     questions = ["When was this article written?", "When was this article written?"]
-    press = ChunkPress(press=SnapKVPress(compression_ratio=0.4, window_size=3), chunk_length=5, global_scoring=True)
+    press = ExpectedAttentionPress(compression_ratio=0.4)
     tokenizer = AutoTokenizer.from_pretrained(model.config.name_or_path)
     answers = KVPressTextGenerationPipeline(model=model, tokenizer=tokenizer)(
         context, questions=questions, press=press


### PR DESCRIPTION
## PR Description

Add ChunkKV paper implementation (https://arxiv.org/abs/2502.00299)

### Benchmark Results
Results on Ruler (4096) dataset under different compression ratios (0.1, 0.25, 0.5):

| Task | 0.1 | 0.25 | 0.5 |
|------|-----|------|-----|
| cwe | 99.66 | 99.48 | 97.14 |
| fwe | 94.47 | 94.33 | 93.53 |
| niah_multikey_1 | 99.0 | 95.4 | 82.4 |
| niah_multikey_2 | 86.8 | 65.6 | 41.8 |
| niah_multikey_3 | 86.8 | 60.4 | 27.4 |
| niah_multiquery | 98.85 | 93.55 | 76.85 |
| niah_multivalue | 98.15 | 91.05 | 77.6 |
| niah_single_1 | 100.0 | 100.0 | 100.0 |
| niah_single_2 | 99.2 | 97.6 | 90.0 |
| niah_single_3 | 89.6 | 71.8 | 51.8 |
| qa_1 | 87.8 | 86.0 | 82.6 |
| qa_2 | 61.0 | 60.4 | 76.85 |
| vt | 99.88 | 99.88 | 77.6 |
| Average | 92.40 | 85.81 | 75.04 |

## New press checklist

- [x] I added `mypress_press.py` in the `presses` directory
- [x] I added `MyPress` in `__init__.py` 
- [x] I updated the `README.md` with a 1 liner about my new press in the Available presses section
- [ ] I added my press in the `default_presses` list in `tests/default_presses.py`
