### PR TITLE
Update copyright

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,9 +2,9 @@
 
 Description of your PR. Fixes # (issue) (if applicable)
 
-## New press checklist (if applicable)
-
-- [ ] I added `mypress_press.py` in the `presses` directory
-- [ ] I added `MyPress` in `__init__.py` 
-- [ ] I updated the `README.md` with a 1 liner about my new press in the Available presses section
-- [ ] I added my press in the `default_presses` list in `tests/default_presses.py`
+## Checklist
+- [ ] I signed-off all my commits using `git commit -s`
+- [ ] (new press) I added `mypress_press.py` in the `presses` directory
+- [ ] (new press) I added `MyPress` in `__init__.py` 
+- [ ] (new press) I updated the `README.md` with a 1 liner about my new press in the Available presses section
+- [ ] (new press) I added my press in the `default_presses` list in `tests/default_presses.py`

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,8 +3,12 @@
 Description of your PR. Fixes # (issue) (if applicable)
 
 ## Checklist
-- [ ] I signed-off all my commits using `git commit -s`
-- [ ] (new press) I added `mypress_press.py` in the `presses` directory
-- [ ] (new press) I added `MyPress` in `__init__.py` 
-- [ ] (new press) I updated the `README.md` with a 1 liner about my new press in the Available presses section
-- [ ] (new press) I added my press in the `default_presses` list in `tests/default_presses.py`
+
+- Tests are working (make test)
+- Code is formatted correctly (make style, on errors try fix with make format)
+- Copyright header is included
+- [ ] All commits are signed-off  using `git commit -s`
+- [ ] (new press) `mypress_press.py` is in the `presses` directory
+- [ ] (new press) `MyPress` is in `__init__.py` 
+- [ ] (new press) `README.md` is updated with a 1 liner about the new press in the Available presses section
+- [ ] (new press) new press is in the `default_presses` list in `tests/default_presses.py`

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,6 +5,9 @@ authors:
   given-names: "Simon"
 - family-names: "Jeblick"
   given-names: "Maximilian"
+- family-names: "Austin"
+  given-names: "David"
 title: "kvpress"
-date-released: 2024-13-11
+date-released: 2024-11-13
+year: 2024
 url: "https://github.com/NVIDIA/kvpress"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,10 @@
+cff-version: 1.2.0
+message: "If you use kvpress, please cite it as below."
+authors:
+- family-names: "Jegou"
+  given-names: "Simon"
+- family-names: "Jeblick"
+  given-names: "Maximilian"
+title: "kvpress"
+date-released: 2024-13-11
+url: "https://github.com/NVIDIA/kvpress"

--- a/README.md
+++ b/README.md
@@ -113,7 +113,6 @@ By default, the `DynamicCache` is used (no quantization).
 > [!IMPORTANT]  
 > To use the `QuantizedCache`, you need to install additional dependencies (_e.g._ `pip install optimum-quanto`).
 
-
 ## FAQ
 
 <details><summary> 
@@ -122,6 +121,19 @@ By default, the `DynamicCache` is used (no quantization).
 </summary>
 
 Some presses depend on the model architecture (_e.g._ `ExpectedAttentionPress` or `SnapKVPress`) hence they might not work with all models. We tested support for `LlamaForCausalLM`, `MistralForCausalLM`, `Phi3ForCausalLM` and `Qwen2ForCausalLM` but many other models might be supported out of the box because their implementation is often similar in transformers.
+</details>
+
+<details><summary> 
+
+### How to run inference on multiple GPUs ? 
+</summary>
+
+kvpress supports multi-GPU inference through [accelerate](https://huggingface.co/docs/accelerate/en/index):
+
+```python
+pipe = pipeline("kv-press-text-generation", model=model, device_map="auto")
+```
+
 </details>
 
 

--- a/evaluation/__init__.py
+++ b/evaluation/__init__.py
@@ -1,2 +1,2 @@
-# SPDX-FileCopyrightText: Copyright (c) 1993-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0

--- a/evaluation/evaluate.py
+++ b/evaluation/evaluate.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 1993-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import json

--- a/evaluation/infinite_bench/calculate_metrics.py
+++ b/evaluation/infinite_bench/calculate_metrics.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 1993-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/evaluation/infinite_bench/create_huggingface_dataset.py
+++ b/evaluation/infinite_bench/create_huggingface_dataset.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 1993-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/evaluation/loogle/__init__.py
+++ b/evaluation/loogle/__init__.py
@@ -1,2 +1,2 @@
-# SPDX-FileCopyrightText: Copyright (c) 1993-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0

--- a/evaluation/loogle/calculate_metrics.py
+++ b/evaluation/loogle/calculate_metrics.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 1993-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/evaluation/loogle/create_huggingface_dataset.py
+++ b/evaluation/loogle/create_huggingface_dataset.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 1993-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/evaluation/ruler/__init__.py
+++ b/evaluation/ruler/__init__.py
@@ -1,2 +1,2 @@
-# SPDX-FileCopyrightText: Copyright (c) 1993-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0

--- a/evaluation/ruler/calculate_metrics.py
+++ b/evaluation/ruler/calculate_metrics.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 1993-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/evaluation/ruler/create_huggingface_dataset.py
+++ b/evaluation/ruler/create_huggingface_dataset.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 1993-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/evaluation/zero_scrolls/__init__.py
+++ b/evaluation/zero_scrolls/__init__.py
@@ -1,2 +1,2 @@
-# SPDX-FileCopyrightText: Copyright (c) 1993-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0

--- a/evaluation/zero_scrolls/calculate_metrics.py
+++ b/evaluation/zero_scrolls/calculate_metrics.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 1993-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/evaluation/zero_scrolls/create_huggingface_dataset.py
+++ b/evaluation/zero_scrolls/create_huggingface_dataset.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 1993-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/kvpress/__init__.py
+++ b/kvpress/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 1993-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/kvpress/pipeline.py
+++ b/kvpress/pipeline.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 1993-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/kvpress/presses/__init__.py
+++ b/kvpress/presses/__init__.py
@@ -1,2 +1,2 @@
-# SPDX-FileCopyrightText: Copyright (c) 1993-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0

--- a/kvpress/presses/adakv_press.py
+++ b/kvpress/presses/adakv_press.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 1993-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/kvpress/presses/base_press.py
+++ b/kvpress/presses/base_press.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 1993-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/kvpress/presses/chunk_press.py
+++ b/kvpress/presses/chunk_press.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 1993-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 from dataclasses import dataclass

--- a/kvpress/presses/chunkkv_press.py
+++ b/kvpress/presses/chunkkv_press.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 1993-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 from dataclasses import dataclass

--- a/kvpress/presses/criticalkv_press.py
+++ b/kvpress/presses/criticalkv_press.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 1993-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/kvpress/presses/duo_attention_press.py
+++ b/kvpress/presses/duo_attention_press.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 1993-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 from contextlib import contextmanager

--- a/kvpress/presses/expected_attention_press.py
+++ b/kvpress/presses/expected_attention_press.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 1993-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/kvpress/presses/key_rerotation_press.py
+++ b/kvpress/presses/key_rerotation_press.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 1993-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/kvpress/presses/knorm_press.py
+++ b/kvpress/presses/knorm_press.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 1993-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/kvpress/presses/observed_attention_press.py
+++ b/kvpress/presses/observed_attention_press.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 1993-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/kvpress/presses/per_layer_compression_press.py
+++ b/kvpress/presses/per_layer_compression_press.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 1993-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/kvpress/presses/random_press.py
+++ b/kvpress/presses/random_press.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 1993-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/kvpress/presses/scorer_press.py
+++ b/kvpress/presses/scorer_press.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 1993-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/kvpress/presses/snapkv_press.py
+++ b/kvpress/presses/snapkv_press.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 1993-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/kvpress/presses/streaming_llm_press.py
+++ b/kvpress/presses/streaming_llm_press.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 1993-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/kvpress/presses/think_press.py
+++ b/kvpress/presses/think_press.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 1993-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/kvpress/presses/tova_press.py
+++ b/kvpress/presses/tova_press.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 1993-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "kvpress"
 authors = ["Simon Jegou", "Maximilian Jeblick", "Jiwei Liu", "David Austin"]
 description = "Efficiently compress the KV cache of any pretrained transformer"
-version = "0.2.3"
+version = "0.2.4"
 readme = "README.md"
 
 [tool.poetry.dependencies]

--- a/tests/default_presses.py
+++ b/tests/default_presses.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 1993-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 1993-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/presses/test_key_rerotation_press_rope.py
+++ b/tests/presses/test_key_rerotation_press_rope.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 1993-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/presses/test_observed_attention_press.py
+++ b/tests/presses/test_observed_attention_press.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 1993-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/presses/test_presses.py
+++ b/tests/presses/test_presses.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 1993-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 from dataclasses import dataclass
 

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 1993-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/test_per_layer_compression_press.py
+++ b/tests/test_per_layer_compression_press.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 1993-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 1993-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/test_press_call.py
+++ b/tests/test_press_call.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 1993-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 


### PR DESCRIPTION
- update copyright from 2024 to 2025
- add CITATION.cff
- update FAQ with section on multi-gpu (see #53)
- update to v0.2.4 (to be merged after #54)