### PR TITLE
Add DuoAttention on the fly

### DIFF
--- a/evaluation/evaluate.py
+++ b/evaluation/evaluate.py
@@ -30,6 +30,7 @@ from kvpress import (
     StreamingLLMPress,
     ThinKPress,
     TOVAPress,
+    QFilterPress,
 )
 
 logger = logging.getLogger(__name__)
@@ -67,6 +68,7 @@ PRESS_DICT = {
     "duo_attention": DuoAttentionPress(),
     "duo_attention_on_the_fly": DuoAttentionPress(on_the_fly_scoring=True),
     "chunkkv": ChunkKVPress(press=SnapKVPress(), chunk_length=20),
+    "qfilter": QFilterPress(),
 }
 
 

--- a/evaluation/evaluate.py
+++ b/evaluation/evaluate.py
@@ -79,6 +79,7 @@ PRESS_DICT = {
     "duo_attention_on_the_fly": DuoAttentionPress(on_the_fly_scoring=True),
     "chunkkv": ChunkKVPress(press=SnapKVPress(), chunk_length=20),
     "qfilter": QFilterPress(),
+    "snap_think": ComposedPress([SnapKVPress(), ThinKPress()]),
 }
 
 

--- a/evaluation/evaluate.py
+++ b/evaluation/evaluate.py
@@ -65,6 +65,7 @@ PRESS_DICT = {
     "think": ThinKPress(),
     "tova": TOVAPress(),
     "duo_attention": DuoAttentionPress(),
+    "duo_attention_on_the_fly": DuoAttentionPress(on_the_fly_scoring=True),
     "chunkkv": ChunkKVPress(press=SnapKVPress(), chunk_length=20),
 }
 

--- a/kvpress/presses/duo_attention_press.py
+++ b/kvpress/presses/duo_attention_press.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from cachetools import cached, LRUCache
+from cachetools import cached, LRUCache  # type: ignore[import-untyped]
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from io import StringIO

--- a/kvpress/presses/duo_attention_press.py
+++ b/kvpress/presses/duo_attention_press.py
@@ -38,7 +38,7 @@ class DuoAttentionPress(BasePress):
 
     Head classification is based on scores.
     - If on_the_fly_scoring=False, scores are loaded from https://github.com/mit-han-lab/duo-attention/
-    - (experimental) If on_the_fly_scoring=True, scores are computed using duo_attention_on_the_fly 
+    - (experimental) If on_the_fly_scoring=True, scores are computed using duo_attention_on_the_fly
     """
 
     head_compression_ratio: float = 0.0

--- a/kvpress/presses/qfilter_press.py
+++ b/kvpress/presses/qfilter_press.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from cachetools import cached, LRUCache
+from functools import cache
 from contextlib import contextmanager
 from dataclasses import dataclass
 
@@ -27,13 +27,13 @@ class QFilterPress(ScorerPress):
     Prune KV pairs with Q-filters
     """
 
-    @cached(LRUCache(maxsize=128), key=lambda self, model: model.config.name_or_path)
     def __post_init_from_model__(self, model):
         model_name = model.config.name_or_path.split("/")[-1]
         self.q_filters = self.load_q_filters(model_name)
         self.q_filters = self.q_filters.to(model.dtype)
 
     @staticmethod
+    @cache
     def load_q_filters(model_name):
         try:
             return QFilters.from_pretrained(f"nthngdy/{model_name}_qfilt").q_filters

--- a/kvpress/presses/qfilter_press.py
+++ b/kvpress/presses/qfilter_press.py
@@ -27,9 +27,11 @@ class QFilterPress(ScorerPress):
     """
 
     def __post_init_from_model__(self, model):
-        model_name = model.config.name_or_path.split("/")[-1]
-        self.q_filters = self.load_q_filters(model_name)
-        self.q_filters = self.q_filters.to(model.dtype)
+        if getattr(self, "_post_init_model_name", None) != model.config.name_or_path:
+            model_name = model.config.name_or_path.split("/")[-1]
+            self.q_filters = self.load_q_filters(model_name)
+            self.q_filters = self.q_filters.to(model.dtype)
+            self._post_init_model_name = model.config.name_or_path
 
     @staticmethod
     def load_q_filters(model_name):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ rouge = "^1.0.1"
 bert-score = "^0.3.13"
 accelerate = "^1.0.0"
 requests = "^2.32.3"
+cachetools = "^5.5.2"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.0.0"


### PR DESCRIPTION
This PR fixes #62 and propose a new way to compute DuoAttention scores for classification of streaming and retrieval heads. I will report results based on this PR in this branch.