### PR TITLE
Add PyramidKVPress

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Several presses inherit from `ScorerPress` ([source](kvpress/presses/scorer_pres
 - `TOVAPress` ([source](kvpress/presses/tova_press.py), [paper](https://arxiv.org/abs/2401.06104)): attention weight of the last query averaged across heads 
 - `ObservedAttentionPress` ([source](kvpress/presses/observed_attention_press.py), [paper](https://arxiv.org/abs/2306.14048)): average attention weight observed during in pre-filling phase
 - `QFilterPress` ([source](kvpress/presses/qfilter_press.py), [paper](https://arxiv.org/abs/2503.02812)): project the Key representations on the main SVD component of the Query vectors to approximate the attention scores.
+- `PyramidKVPress` ([source](kvpress/presses/pyramidkv_press.py), [paper](https://arxiv.org/abs/2406.02069)): maintain pyramid-like cache sizes, allocating more cache budget to lower layers and less to higher layers
 
 Some presses rely on a different logic:
 - `ThinKPress` ([source](kvpress/presses/think_press.py), [paper](https://arxiv.org/pdf/2407.21018)): compress the dimensions of the keys based on the channel attention score on the last queries 

--- a/evaluation/evaluate.py
+++ b/evaluation/evaluate.py
@@ -35,6 +35,7 @@ from kvpress import (
     ThinKPress,
     TOVAPress,
     QFilterPress,
+    PyramidKVPress,
 )
 
 logger = logging.getLogger(__name__)
@@ -80,6 +81,7 @@ PRESS_DICT = {
     "chunkkv": ChunkKVPress(press=SnapKVPress(), chunk_length=20),
     "qfilter": QFilterPress(),
     "snap_think": ComposedPress([SnapKVPress(), ThinKPress()]),
+    "pyramidkv": PyramidKVPress(),
 }
 
 

--- a/kvpress/__init__.py
+++ b/kvpress/__init__.py
@@ -24,6 +24,7 @@ from kvpress.presses.streaming_llm_press import StreamingLLMPress
 from kvpress.presses.think_press import ThinKPress
 from kvpress.presses.tova_press import TOVAPress
 from kvpress.presses.qfilter_press import QFilterPress
+from kvpress.presses.pyramidkv_press import PyramidKVPress
 
 # Patch the attention functions to support head-wise compression
 patch_attention_functions()
@@ -51,4 +52,5 @@ __all__ = [
     "DuoAttentionPress",
     "ChunkKVPress",
     "QFilterPress",
+    "PyramidKVPress",
 ]

--- a/kvpress/presses/pyramidkv_press.py
+++ b/kvpress/presses/pyramidkv_press.py
@@ -21,6 +21,16 @@ class PyramidKVPress(SnapKVPress):
 
     We use the budget calculation formula from:
     https://github.com/Zefan-Cai/KVCache-Factory/blob/main/pyramidkv/pyramidkv_utils.py#L197
+
+    This implementation always applies compression_ratio,
+    instead of disabling compression or keeping fixed budget for short queries like the original code.
+
+    max_capacity_prompt is calculated as:
+    max_num + min_num   &= (max_capacity_prompt - window_size) * 2
+    total_kvcache_size  &= \frac{(max_num + min_num) * num_layers}{2}
+                        &= (max_capacity_prompt - window_size) * num_layers
+    total_kvcache_size  &= query_length * num_layers * (1 - compression_ratio)
+    max_capacity_prompt &= window_size + query_length * (1 - compression_ratio)
     """
 
     compression_ratio: float = 0.0
@@ -39,9 +49,9 @@ class PyramidKVPress(SnapKVPress):
         assert self.beta >= 1, "Beta should >= 1"
 
         # Ensure the total budget meets the compression_ratio requirements
-        max_capacity_prompt = self.window_size + int(q_len * (1 - self.compression_ratio))
+        max_capacity_prompt = self.window_size + q_len * (1 - self.compression_ratio)
 
-        min_num = (max_capacity_prompt - self.window_size) // self.beta
+        min_num = (max_capacity_prompt - self.window_size) / self.beta
         max_num = (max_capacity_prompt - self.window_size) * 2 - min_num
 
         if max_num >= q_len - self.window_size:
@@ -50,13 +60,11 @@ class PyramidKVPress(SnapKVPress):
 
         if not (q_len >= max_num >= min_num >= self.window_size):
             # Fall back to SnapKV
-            max_num = int(q_len * (1 - self.compression_ratio))
-            min_num = max_num
+            return round(q_len * (1 - self.compression_ratio))
 
-        steps = (max_num - min_num) // (module.config.num_hidden_layers - 1)
-        return max_num - module.layer_idx * steps
+        steps = (max_num - min_num) / (module.config.num_hidden_layers - 1)
+        return round(max_num - module.layer_idx * steps)
 
-    # Overriding ScorerPress compress method
     def compress(
         self,
         module: nn.Module,

--- a/kvpress/presses/pyramidkv_press.py
+++ b/kvpress/presses/pyramidkv_press.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
+import logging
+from dataclasses import dataclass
+
+import torch
+from torch import nn
+
+from kvpress.presses.snapkv_press import SnapKVPress
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PyramidKVPress(SnapKVPress):
+    """
+    PyramidKV (https://arxiv.org/abs/2406.02069) dynamically adjusts KV cache sizes across layers,
+    allocating more in lower layers and less in higher layers.
+
+    We use the budget calculation formula from:
+    https://github.com/Zefan-Cai/KVCache-Factory/blob/main/pyramidkv/pyramidkv_utils.py#L197
+    """
+
+    compression_ratio: float = 0.0
+    window_size: int = 64
+    kernel_size: int = 5
+    beta: int = 20  # a hyperparameter to adjust the pyramid’s shape
+
+    def get_layer_budget(
+        self,
+        module: nn.Module,
+        q_len: int,
+    ) -> int:
+        """
+        Compute the budget for each layer based on the pyramid shape.
+        """
+        # Ensure the total budget meets the compression_ratio requirements
+        max_capacity_prompt = self.window_size + round(q_len * (1 - self.compression_ratio))
+
+        min_num = (max_capacity_prompt - self.window_size) // self.beta
+        max_num = (max_capacity_prompt - self.window_size) * 2 - min_num
+
+        if max_num >= q_len - self.window_size:
+            max_num = q_len - self.window_size
+            min_num = (max_capacity_prompt - self.window_size) * 2 - max_num
+
+        steps = (max_num - min_num) // (module.config.num_hidden_layers - 1)
+        return max_num - module.layer_idx * steps
+
+    # Overriding ScorerPress compress method
+    def compress(
+        self,
+        module: nn.Module,
+        hidden_states: torch.Tensor,
+        keys: torch.Tensor,
+        values: torch.Tensor,
+        attentions: torch.Tensor,
+        kwargs: dict,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+
+        if self.compression_ratio == 0:
+            return keys, values
+
+        # Compute scores
+        scores = self.score(module, hidden_states, keys, values, attentions, kwargs)
+
+        # Get indices of KV pairs with the lowest scores
+        q_len = hidden_states.shape[1]
+        n_kept = self.get_layer_budget(module, q_len)
+        indices = scores.topk(n_kept, dim=-1).indices
+        indices = indices.unsqueeze(-1).expand(-1, -1, -1, module.head_dim)
+
+        # Prune keys and values
+        keys = keys.gather(2, indices).contiguous()
+        values = values.gather(2, indices).contiguous()
+
+        return keys, values

--- a/kvpress/presses/snapkv_press.py
+++ b/kvpress/presses/snapkv_press.py
@@ -88,7 +88,7 @@ class SnapKVPress(ScorerPress):
         scores = attn_weights.mean(dim=-2)
         scores = F.avg_pool1d(scores, kernel_size=self.kernel_size, padding=self.kernel_size // 2, stride=1)
 
-        # Average per grioup (https://github.com/FasterDecoding/SnapKV/issues/22)
+        # Average per group (https://github.com/FasterDecoding/SnapKV/issues/22)
         scores = scores.view(bsz, num_key_value_heads, num_key_value_groups, q_len - self.window_size)
         scores = scores.mean(2)
 

--- a/tests/default_presses.py
+++ b/tests/default_presses.py
@@ -14,6 +14,7 @@ from kvpress import (
     ThinKPress,
     TOVAPress,
     QFilterPress,
+    PyramidKVPress,
 )
 
 
@@ -51,5 +52,9 @@ default_presses = [
             {"lazy_threshold": 0.8, "n_initial": 1, "n_recent": 1, "n_last": 1},
             {"lazy_threshold": 0.2, "n_initial": 1, "n_recent": 1, "n_last": 1},
         ],
+    },
+    {
+        "cls": PyramidKVPress,
+        "kwargs": [{"compression_ratio": 0.2, "window_size": 2}, {"compression_ratio": 0.8, "window_size": 2}],
     },
 ]

--- a/tests/presses/test_pyramidkv_press.py
+++ b/tests/presses/test_pyramidkv_press.py
@@ -1,0 +1,45 @@
+import pytest
+from kvpress.presses.pyramidkv_press import PyramidKVPress
+import torch.nn as nn
+
+
+class MockConfig:
+    def __init__(self, num_hidden_layers):
+        self.num_hidden_layers = num_hidden_layers
+
+
+class MockModule(nn.Module):
+    def __init__(self, config, layer_idx):
+        super().__init__()
+        self.config = config
+        self.layer_idx = layer_idx
+
+
+def scorer_press_layer_budget(q_len, compression_ratio):
+    return round(q_len * (1 - compression_ratio))
+
+
+@pytest.mark.parametrize("layer_budget_func", ["pyramidkv_press_layer_budget", "scorer_press_layer_budget"])
+@pytest.mark.parametrize("num_hidden_layers", [32, 64, 128])
+@pytest.mark.parametrize("compression_ratio", [0.1, 0.25, 0.3, 0.5, 0.6, 0.75, 0.8])
+@pytest.mark.parametrize("q_len", [1024, 2787, 4096, 6591, 8192])
+def test_mean_layer_budget(layer_budget_func, num_hidden_layers, compression_ratio, q_len):
+    total_n_kept = 0
+
+    if layer_budget_func == "pyramidkv_press_layer_budget":
+        config = MockConfig(num_hidden_layers)
+        press = PyramidKVPress()
+        press.compression_ratio = compression_ratio
+
+    for layer_idx in range(num_hidden_layers):
+        if layer_budget_func == "pyramidkv_press_layer_budget":
+            module = MockModule(config, layer_idx)
+            n_kept = press.get_layer_budget(module, q_len)
+        elif layer_budget_func == "scorer_press_layer_budget":
+            n_kept = scorer_press_layer_budget(q_len, compression_ratio)
+        else:
+            raise ValueError(f"Unsupported layer_budget_func: {layer_budget_func}")
+        total_n_kept += n_kept
+
+    mean_n_kept = total_n_kept / num_hidden_layers
+    assert mean_n_kept == pytest.approx(q_len * (1 - compression_ratio), rel=1e-3)


### PR DESCRIPTION
## PR description

Add support for PyramidKVPress (https://github.com/NVIDIA/kvpress/issues/65) based on the original author's [code](https://github.com/Zefan-Cai/KVCache-Factory). It maintains pyramid-like cache sizes, allocating more cache budget to lower layers and less to higher layers.

It performs slightly worse on the RULER 4k dataset than SnapKV.
![2db20cfa-4d76-4e63-9b98-eb5a2ef1411c](https://github.com/user-attachments/assets/5d5735d3-a703-4789-a774-1348f4deb000)

## Checklist

- Tests are working (make test)
```
=============== 100 passed, 23 skipped, 2 warnings in 59.27s ================
```

- Code is formatted correctly (make style, on errors try fix with make format)
```
Found 27 errors in 2 files (checked 42 source files)
make: *** [Makefile:28: style] Error 1
```
But none of them related to my PR.

- Copyright header is included
- [x] All commits are signed-off  using `git commit -s`
- [x] (new press) `mypress_press.py` is in the `presses` directory
- [x] (new press) `MyPress` is in `__init__.py` 
- [x] (new press) `README.md` is updated with a 1 liner about the new press in the Available presses section
- [x] (new press) new press is in the `default_presses` list in `tests/default_presses.py`

