### PR TITLE
Align dev dependencies with new poetry format

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ accelerate = "^1.0.0"
 requests = "^2.32.3"
 cachetools = "^5.5.2"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = "^7.0.0"
 flake8 = "^7.0.0"
 isort = "^5.13.2"


### PR DESCRIPTION
## PR description

This small PR updates `pyproject.toml` to use the new `[tool.poetry.group.dev.dependencies]` format. It replaces the deprecated `[tool.poetry.dev-dependencies]` section for compatibility with Poetry 1.2+.

## Checklist

- Tests are working (make test)
- Code is formatted correctly (make style, on errors try fix with make format)
- Copyright header is included
- [x] All commits are signed-off  using `git commit -s`
- [ ] (new press) `mypress_press.py` is in the `presses` directory
- [ ] (new press) `MyPress` is in `__init__.py` 
- [ ] (new press) `README.md` is updated with a 1 liner about the new press in the Available presses section
- [ ] (new press) new press is in the `default_presses` list in `tests/default_presses.py`
