### PR TITLE
Add missing SPDX headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ style: reports
 	@echo -n > reports/flake8_errors.log
 	@echo -n > reports/mypy_errors.log
 	@echo -n > reports/mypy.log
+	@echo -n > reports/copyright_errors.log
 	@echo
 
 	-$(POETRY) run flake8 | tee -a reports/flake8_errors.log
@@ -28,6 +29,11 @@ style: reports
 
 	-$(POETRY) run mypy . --check-untyped-defs | tee -a reports/mypy.log
 	@if ! grep -Eq "Success: no issues found in [0-9]+ source files" reports/mypy.log ; then exit 1; fi
+
+	@echo "Checking for SPDX-FileCopyrightText headers in Python files..."
+	@find . -name "*.py" -not -path "*/\.*" | xargs grep -L "SPDX-FileCopyrightText:" | tee reports/copyright_errors.log || true
+	@if [ -s reports/copyright_errors.log ]; then echo "Error: Missing SPDX-FileCopyrightText headers in files listed above"; exit 1; fi
+	@echo "Success: All Python files have SPDX-FileCopyrightText headers."
 
 
 reports:

--- a/kvpress/attention_patch.py
+++ b/kvpress/attention_patch.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
 

--- a/kvpress/presses/composed_press.py
+++ b/kvpress/presses/composed_press.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 from dataclasses import dataclass
 
 from kvpress.presses.adakv_press import AdaKVPress

--- a/kvpress/presses/simlayerkv_press.py
+++ b/kvpress/presses/simlayerkv_press.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 from dataclasses import dataclass
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/integration/test_ruler.py
+++ b/tests/integration/test_ruler.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import datasets
 import pytest
 import torch

--- a/tests/presses/__init__.py
+++ b/tests/presses/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/presses/test_duo_attention_press.py
+++ b/tests/presses/test_duo_attention_press.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 from kvpress.presses.duo_attention_press import PATTERNS_DICT, DuoAttentionPress
 
 

--- a/tests/presses/test_finch_press.py
+++ b/tests/presses/test_finch_press.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 from kvpress import FinchPress
 from tests.fixtures import unit_test_model  # noqa: F401

--- a/tests/presses/test_pyramidkv_press.py
+++ b/tests/presses/test_pyramidkv_press.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 from kvpress.presses.pyramidkv_press import PyramidKVPress
 import torch.nn as nn

--- a/tests/test_attention_patch.py
+++ b/tests/test_attention_patch.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 
 from kvpress.attention_patch import search_hyperplane


### PR DESCRIPTION
## PR description

This PR adds a check for SPDX-FileCopyrightText headers and fixes some missing headers.

## Checklist

- Tests are working (make test)
- Code is formatted correctly (make style, on errors try fix with make format)
- Copyright header is included
- [x] All commits are signed-off  using `git commit -s`
- [ ] (new press) `mypress_press.py` is in the `presses` directory
- [ ] (new press) `MyPress` is in `__init__.py` 
- [ ] (new press) `README.md` is updated with a 1 liner about the new press in the Available presses section
- [ ] (new press) new press is in the `default_presses` list in `tests/default_presses.py`
