### PR TITLE
Improve documentation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,11 +4,12 @@ Description of your PR. Fixes # (issue) (if applicable)
 
 ## Checklist
 
-- Tests are working (make test)
-- Code is formatted correctly (make style, on errors try fix with make format)
+- Tests are working (`make test`)
+- Code is formatted correctly (`make style`, on errors try fix with `make format`)
 - Copyright header is included
 - [ ] All commits are signed-off  using `git commit -s`
 - [ ] (new press) `mypress_press.py` is in the `presses` directory
 - [ ] (new press) `MyPress` is in `__init__.py` 
 - [ ] (new press) `README.md` is updated with a 1 liner about the new press in the Available presses section
-- [ ] (new press) new press is in the `default_presses` list in `tests/default_presses.py`
+- [ ] (new press) New press is in the `default_presses` list in `tests/default_presses.py`
+- [ ] (new press) A docstring is provided that follows the same structure as the existing ones

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Finally we provide wrapper presses that can be combined with other presses:
 - `ChunkKVPress` ([source](kvpress/presses/chunkkv_press.py), [paper](https://arxiv.org/abs/2502.00299)): compresses by selecting important chunks, preserving semantic coherence
 - `ChunkPress` ([source](kvpress/presses/chunk_press.py), [paper](https://direct.mit.edu/tacl/article/doi/10.1162/tacl_a_00716/125280)): compress the KV cache on each sequence chunk separately. This can yield to more uniform compression across long sequences
 - `CriticalKVPress` and `CriticalAdaKVPress` ([source](kvpress/presses/criticalkv_press.py), [paper](https://arxiv.org/abs/2502.03805)): refine the scores using the L1 norm of Wo @ values, coupled with a two-stage selection.
-- `BlockPress` ([source](kvpress/presses/keydiff_press.py), [paper](https://arxiv.org/abs/2504.15364)): segments input sequence into non-overlapping blocks and compresses iteratively.
+- `BlockPress` ([source](kvpress/presses/block_press.py), [paper](https://arxiv.org/abs/2504.15364)): segments input sequence into non-overlapping blocks and compresses iteratively.
 
 For a detailed list of existing KV cache compression methods, check [Awesome-KV-Cache-Compression](https://github.com/October2001/Awesome-KV-Cache-Compression) or [Awesome-LLM-Compression](https://github.com/HuangOwen/Awesome-LLM-Compression?tab=readme-ov-file#kv-cache-compression)
 
@@ -134,7 +134,7 @@ By default, the `DynamicCache` is used (no quantization).
 ### Which models are supported ? 
 </summary>
 
-Some presses depend on the model architecture (_e.g._ `ExpectedAttentionPress` or `SnapKVPress`) hence they might not work with all models. We tested support for `LlamaForCausalLM`, `MistralForCausalLM`, `Phi3ForCausalLM` and `Qwen2ForCausalLM` but many other models might be supported out of the box because their implementation is often similar in transformers.
+Some presses depend on the model architecture (_e.g._ `ExpectedAttentionPress` or `SnapKVPress`) hence they might not work with all models. We tested support for `LlamaForCausalLM`, `MistralForCausalLM`, `Phi3ForCausalLM`, `Qwen2ForCausalLM`, `Qwen3ForCausalLM`, and `Gemma3ForCausalLM` but many other models might be supported out of the box because their implementation is often similar in transformers.
 </details>
 
 <details><summary> 

--- a/evaluation/evaluate.py
+++ b/evaluation/evaluate.py
@@ -21,6 +21,7 @@ from zero_scrolls.calculate_metrics import calculate_metrics as zero_scrolls_sco
 
 from kvpress import (
     AdaKVPress,
+    BlockPress,
     ChunkKVPress,
     ComposedPress,
     CriticalAdaKVPress,
@@ -28,6 +29,7 @@ from kvpress import (
     DuoAttentionPress,
     ExpectedAttentionPress,
     FinchPress,
+    KeyDiffPress,
     KnormPress,
     ObservedAttentionPress,
     PyramidKVPress,
@@ -37,8 +39,6 @@ from kvpress import (
     StreamingLLMPress,
     ThinKPress,
     TOVAPress,
-    BlockPress,
-    KeyDiffPress,
 )
 
 logger = logging.getLogger(__name__)

--- a/evaluation/longbench/calculate_metrics.py
+++ b/evaluation/longbench/calculate_metrics.py
@@ -4,6 +4,7 @@
 import re
 import string
 from collections import Counter
+
 import numpy as np
 from rouge import Rouge
 
@@ -37,7 +38,7 @@ def calculate_metrics_e(df):
 
 def scorer_e(dataset, predictions, answers, lengths, all_classes):
     scores = {"0-4k": [], "4-8k": [], "8k+": []}  # type:ignore[var-annotated]
-    for (prediction, ground_truths, length) in zip(predictions, answers, lengths):
+    for prediction, ground_truths, length in zip(predictions, answers, lengths):
         score = 0.0
         if dataset in ["trec", "triviaqa", "samsum", "lsht"]:
             prediction = prediction.lstrip("\n").split("\n")[0]
@@ -56,7 +57,7 @@ def scorer_e(dataset, predictions, answers, lengths, all_classes):
 
 def scorer(dataset, predictions, answers, all_classes):
     total_score = 0.0
-    for (prediction, ground_truths) in zip(predictions, answers):
+    for prediction, ground_truths in zip(predictions, answers):
         score = 0.0
         if dataset in ["trec", "triviaqa", "samsum", "lsht"]:
             prediction = prediction.lstrip("\n").split("\n")[0]

--- a/kvpress/__init__.py
+++ b/kvpress/__init__.py
@@ -5,17 +5,23 @@
 from kvpress.attention_patch import patch_attention_functions
 from kvpress.pipeline import KVPressTextGenerationPipeline
 from kvpress.presses.adakv_press import AdaKVPress
-from kvpress.presses.base_press import BasePress
+from kvpress.presses.base_press import SUPPORTED_MODELS, BasePress
+from kvpress.presses.block_press import BlockPress
 from kvpress.presses.chunk_press import ChunkPress
 from kvpress.presses.chunkkv_press import ChunkKVPress
 from kvpress.presses.composed_press import ComposedPress
 from kvpress.presses.criticalkv_press import CriticalAdaKVPress, CriticalKVPress
 from kvpress.presses.duo_attention_press import DuoAttentionPress
 from kvpress.presses.expected_attention_press import ExpectedAttentionPress
+from kvpress.presses.finch_press import FinchPress
 from kvpress.presses.key_rerotation_press import KeyRerotationPress
+from kvpress.presses.keydiff_press import KeyDiffPress
 from kvpress.presses.knorm_press import KnormPress
+from kvpress.presses.lagkv_press import LagKVPress
 from kvpress.presses.observed_attention_press import ObservedAttentionPress
 from kvpress.presses.per_layer_compression_press import PerLayerCompressionPress
+from kvpress.presses.pyramidkv_press import PyramidKVPress
+from kvpress.presses.qfilter_press import QFilterPress
 from kvpress.presses.random_press import RandomPress
 from kvpress.presses.scorer_press import ScorerPress
 from kvpress.presses.simlayerkv_press import SimLayerKVPress
@@ -23,13 +29,6 @@ from kvpress.presses.snapkv_press import SnapKVPress
 from kvpress.presses.streaming_llm_press import StreamingLLMPress
 from kvpress.presses.think_press import ThinKPress
 from kvpress.presses.tova_press import TOVAPress
-from kvpress.presses.qfilter_press import QFilterPress
-from kvpress.presses.pyramidkv_press import PyramidKVPress
-from kvpress.presses.finch_press import FinchPress
-from kvpress.presses.lagkv_press import LagKVPress
-from kvpress.presses.base_press import SUPPORTED_MODELS
-from kvpress.presses.block_press import BlockPress
-from kvpress.presses.keydiff_press import KeyDiffPress
 
 # Patch the attention functions to support head-wise compression
 patch_attention_functions()

--- a/kvpress/attention_patch.py
+++ b/kvpress/attention_patch.py
@@ -96,11 +96,6 @@ def patch_attention_functions():
     after this function is called. It's automatically called when importing
     kvpress to ensure compatibility with head-wise compression methods.
 
-    Effects:
-    - Enables head-wise compression methods to mask specific tokens per head
-    - Allows compressed models to generate text correctly during decoding
-    - Maintains compatibility with existing transformer attention implementations
-
     Notes
     -----
     This function modifies the global attention functions in the transformers

--- a/kvpress/attention_patch.py
+++ b/kvpress/attention_patch.py
@@ -99,7 +99,7 @@ def patch_attention_functions():
     Notes
     -----
     This function modifies the global attention functions in the transformers
-    library. The modifications do affect models that don't use head-wise compression (i.e. don't have
+    library. The modifications do not affect models that don't use head-wise compression (i.e. don't have
     module.masked_key_indices).
     """
     for name, func in ALL_ATTENTION_FUNCTIONS.items():

--- a/kvpress/attention_patch.py
+++ b/kvpress/attention_patch.py
@@ -7,15 +7,9 @@ from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
 
 def search_hyperplane(X, max_iter: int = 1000):
     """
-    Search for a hyperplane that makes attention weights zero for masked tokens.
-
-    Given a tensor X representing query vectors, this function finds a hyperplane Y
-    such that the dot product of any query with Y is non-positive. This is used to
-    create "fake" keys that will result in zero attention weights when computed with
-    any query vector.
-
-    The algorithm iteratively refines the hyperplane by incorporating queries that
-    violate the non-positive constraint until all queries satisfy it.
+    Given a tensor X of shape (bsz, seq_len, head_dim), search for an hyperplane Y (bsz, head_dim)
+    such that for every i, <X[:, i], Y> <= 0. Returns - 1e5 * Y / ||Y|| ** 2 to ensure exp(<X, Y>) = 0
+    Raises a ValueError if no such hyperplane is found
 
     Parameters
     ----------
@@ -36,11 +30,6 @@ def search_hyperplane(X, max_iter: int = 1000):
     ------
     ValueError
         If no valid hyperplane is found within max_iter iterations.
-
-    Notes
-    -----
-    The returned hyperplane is scaled to ensure that attention weights computed
-    as exp(<query, hyperplane>) are effectively zero, enabling head-wise masking.
     """
     Y = X.mean(1)  # this initialization is enough for most cases
     for _ in range(max_iter):

--- a/kvpress/pipeline.py
+++ b/kvpress/pipeline.py
@@ -25,14 +25,13 @@ class KVPressTextGenerationPipeline(Pipeline):
     Pipeline for key-value cache compression in causal language models.
 
     Enables efficient processing of long contexts by applying KV cache compression
-    during pre-filling, then generating answers using greedy decoding. Particularly
-    useful for question-answering tasks over long documents.
+    during pre-filling, then generating answers using greedy decoding.
 
     Example:
     ```python
     pipeline = KVPressTextGenerationPipeline(model=model, tokenizer=tokenizer)
     press = SnapKVPress(compression_ratio=0.5)
-    result = pipeline(context="Long text...", question="What?", press=press)
+    result = pipeline(context="Long text...", question="A question about the long context.", press=press)
     ```
     """
 

--- a/kvpress/pipeline.py
+++ b/kvpress/pipeline.py
@@ -23,11 +23,11 @@ logger = logging.getLogger(__name__)
 class KVPressTextGenerationPipeline(Pipeline):
     """
     Pipeline for key-value cache compression in causal language models.
-    
+
     Enables efficient processing of long contexts by applying KV cache compression
     during pre-filling, then generating answers using greedy decoding. Particularly
     useful for question-answering tasks over long documents.
-    
+
     Example:
     ```python
     pipeline = KVPressTextGenerationPipeline(model=model, tokenizer=tokenizer)
@@ -61,7 +61,7 @@ class KVPressTextGenerationPipeline(Pipeline):
             The prefix to be added to the generated answer.
         press : BasePress, optional
             The key-value cache compression method to apply during pre-filling.
-            
+
             Accepts any KVPress compression method (SnapKVPress, KnormPress,
             ExpectedAttentionPress, BlockPress, AdaKVPress, ComposedPress, etc.).
             If None, no compression is applied.
@@ -106,7 +106,7 @@ class KVPressTextGenerationPipeline(Pipeline):
     ):
         """
         Apply chat template and tokenize the context and questions.
-        
+
         Prepares input text for KV cache compression and generation by applying
         appropriate chat templates and tokenizing. Handles models with and without
         chat templates.
@@ -168,7 +168,7 @@ class KVPressTextGenerationPipeline(Pipeline):
     ):
         """
         Execute KV cache compression and text generation pipeline.
-        
+
         Performs context compression using the press method during pre-filling,
         then generates answers using greedy decoding.
 

--- a/kvpress/pipeline.py
+++ b/kvpress/pipeline.py
@@ -24,30 +24,15 @@ class KVPressTextGenerationPipeline(Pipeline):
     """
     Pipeline for key-value cache compression in causal language models.
     
-    This pipeline enables efficient processing of long contexts by applying KV cache
-    compression during the pre-filling phase, then generating answers using greedy
-    decoding. It's particularly useful for question-answering tasks over long documents
-    where the full context needs to be processed but memory constraints are a concern.
+    Enables efficient processing of long contexts by applying KV cache compression
+    during pre-filling, then generating answers using greedy decoding. Particularly
+    useful for question-answering tasks over long documents.
     
-    The pipeline supports:
-    - Single or multiple questions about the same context
-    - Various compression methods (press objects)
-    - Customizable generation parameters
-    - Cache reuse for multiple questions
-    
-    Example usage:
+    Example:
     ```python
-    from kvpress import KVPressTextGenerationPipeline, SnapKVPress
-    
     pipeline = KVPressTextGenerationPipeline(model=model, tokenizer=tokenizer)
     press = SnapKVPress(compression_ratio=0.5)
-    
-    result = pipeline(
-        context="Long document text...",
-        question="What is the main topic?",
-        press=press,
-        max_new_tokens=100
-    )
+    result = pipeline(context="Long text...", question="What?", press=press)
     ```
     """
 
@@ -77,19 +62,9 @@ class KVPressTextGenerationPipeline(Pipeline):
         press : BasePress, optional
             The key-value cache compression method to apply during pre-filling.
             
-            This parameter accepts any KVPress compression method (subclass of BasePress)
-            that defines how to reduce the size of the key-value cache. Common options include:
-            
-            - SnapKVPress: Uses recent attention patterns to identify important tokens
-            - KnormPress: Scores tokens based on key vector norms
-            - ExpectedAttentionPress: Uses expected attention patterns for scoring
-            - BlockPress: Applies compression in blocks for memory efficiency
-            - AdaKVPress: Adaptive head-wise compression with safeguards
-            - ComposedPress: Combines multiple compression methods
-            
-            If None, no compression is applied and the full context is processed.
-            The compression method significantly affects both memory usage and
-            model performance, so choose based on your specific requirements.
+            Accepts any KVPress compression method (SnapKVPress, KnormPress,
+            ExpectedAttentionPress, BlockPress, AdaKVPress, ComposedPress, etc.).
+            If None, no compression is applied.
         max_new_tokens : int, optional
             The maximum number of new tokens to generate for each answer.
         max_context_length : int, optional
@@ -130,42 +105,27 @@ class KVPressTextGenerationPipeline(Pipeline):
         max_context_length: int,
     ):
         """
-        Apply chat template and tokenize the context and questions for processing.
+        Apply chat template and tokenize the context and questions.
         
-        This method prepares the input text for KV cache compression and text generation
-        by applying the appropriate chat template (if available) and tokenizing the
-        context and questions. It handles both models with and without chat templates.
+        Prepares input text for KV cache compression and generation by applying
+        appropriate chat templates and tokenizing. Handles models with and without
+        chat templates.
 
         Parameters
         ----------
         context : str
-            The long context text that will be compressed using the specified press method.
-            This is typically a document, article, or other long-form text that contains
-            the information needed to answer the questions.
+            Long context text to be compressed using the press method.
         questions : list[str]
-            List of questions to be asked about the context. Each question will be
-            processed separately, but they can share the same compressed context for
-            efficiency.
+            Questions to be asked about the context.
         answer_prefix : str
-            Optional prefix to be added to each generated answer. This can be used
-            to format the output or provide consistent answer formatting.
+            Optional prefix for generated answers.
         max_context_length : int
-            Maximum number of tokens allowed in the context. If the tokenized context
-            exceeds this length, it will be truncated to fit within the limit.
+            Maximum tokens allowed in context (truncated if exceeded).
 
         Returns
         -------
         dict[str, GenericTensor]
-            A dictionary containing the tokenized inputs:
-            - "context_ids": Tokenized context ready for compression
-            - "questions_ids": List of tokenized questions for generation
-            
-        Notes
-        -----
-        The method automatically handles different tokenizer configurations:
-        - For models with chat templates: Applies the template with proper formatting
-        - For models without chat templates: Uses simple BOS token prefixing
-        - Ensures proper separation between context and questions
+            Dictionary with "context_ids" and "questions_ids" tensors.
         """
 
         # Apply chat template if available
@@ -207,49 +167,27 @@ class KVPressTextGenerationPipeline(Pipeline):
         cache: Optional[Cache] = None,
     ):
         """
-        Execute the core KV cache compression and text generation pipeline.
+        Execute KV cache compression and text generation pipeline.
         
-        This method performs the main processing steps: context compression using
-        the specified press method, followed by greedy decoding to generate answers
-        for each question. The compression is applied only during the pre-filling
-        phase, while generation uses the compressed cache.
+        Performs context compression using the press method during pre-filling,
+        then generates answers using greedy decoding.
 
         Parameters
         ----------
         input_tensors : dict[str, GenericTensor]
-            Dictionary containing tokenized inputs from the preprocess method:
-            - "context_ids": Tokenized context tensor for compression
-            - "questions_ids": List of tokenized question tensors for generation
+            Tokenized inputs with "context_ids" and "questions_ids".
         max_new_tokens : int, default=50
-            Maximum number of new tokens to generate for each answer. Controls
-            the length of generated responses. Larger values allow longer answers
-            but increase computation time.
+            Maximum tokens to generate for each answer.
         press : BasePress, optional
-            The compression method to apply during context pre-filling. If None,
-            no compression is applied and the full context is used. The press
-            method determines how the KV cache is compressed to save memory.
+            Compression method for context pre-filling. If None, no compression.
         cache : Cache, optional
-            Pre-existing cache object to use for the forward pass. If None,
-            a new DynamicCache is created. Reusing cache objects can be more
-            efficient when processing multiple questions on the same context.
+            Cache object for forward pass. If None, creates new DynamicCache.
 
         Returns
         -------
         list[str]
-            List of generated answers corresponding to each input question.
-            The answers are generated using greedy decoding from the compressed
-            context representation.
-            
-        Notes
-        -----
-        The method follows this processing pipeline:
-        1. Pre-fill the context with compression applied (if press is specified)
-        2. Log compression statistics (original vs compressed context length)
-        3. Generate answers for each question using greedy decoding
-        4. Handle special cases for methods requiring key rerotation
-        5. Return the list of generated text answers
+            Generated answers for each input question.
         """
-
         context_ids = input_tensors["context_ids"].to(self.model.device)
         context_length = context_ids.shape[1]
 

--- a/kvpress/presses/adakv_press.py
+++ b/kvpress/presses/adakv_press.py
@@ -18,19 +18,20 @@ class AdaKVPress(BasePress):
     Performs head-specific compression by selecting top-k tokens across all heads
     based on importance scores. Applies safeguards to ensure each head retains
     a minimum fraction of tokens. Based on AdaKV (https://arxiv.org/abs/2407.11550).
+    
+    Parameters
+    ----------
+    press : ScorerPress
+        The underlying scoring method used to evaluate token importance.
+    alpha_safeguard : float, default=0.20
+        Minimum fraction of KV pairs that each head must retain.
+        Ensures no attention head is compressed too aggressively. Even if tokens
+        receive low global importance scores, each head retains at least this
+        fraction of its original tokens.
     """
 
     press: ScorerPress
-    """The underlying scoring method used to evaluate token importance."""
-    
     alpha_safeguard: float = 0.20
-    """
-    Minimum fraction of KV pairs that each head must retain.
-    
-    Ensures no attention head is compressed too aggressively. Even if tokens
-    receive low global importance scores, each head retains at least this
-    fraction of its original tokens.
-    """
 
     def __post_init__(self):
         assert isinstance(self.press, ScorerPress), "AdaKVPress requires a ScorerPress as input"

--- a/kvpress/presses/adakv_press.py
+++ b/kvpress/presses/adakv_press.py
@@ -24,7 +24,7 @@ class AdaKVPress(BasePress):
     Parameters
     ----------
     press : ScorerPress
-        The underlying scoring method used to evaluate token importance.
+        AdaKVPress and ObservedAttention are currently not supported.
     alpha_safeguard : float, default=0.20
         Minimum fraction of KV pairs that each head must retain.
         Ensures no attention head is compressed too aggressively. Even if tokens

--- a/kvpress/presses/adakv_press.py
+++ b/kvpress/presses/adakv_press.py
@@ -14,11 +14,11 @@ from kvpress.presses.scorer_press import ScorerPress
 class AdaKVPress(BasePress):
     """
     AdaKV: Adaptive head-wise KV cache compression.
-    
+
     Performs head-specific compression by selecting top-k tokens across all heads
     based on importance scores. Applies safeguards to ensure each head retains
     a minimum fraction of tokens. Based on AdaKV (https://arxiv.org/abs/2407.11550).
-    
+
     Parameters
     ----------
     press : ScorerPress

--- a/kvpress/presses/adakv_press.py
+++ b/kvpress/presses/adakv_press.py
@@ -15,23 +15,9 @@ class AdaKVPress(BasePress):
     """
     AdaKV: Adaptive head-wise KV cache compression.
     
-    Based on AdaKV (https://arxiv.org/abs/2407.11550), this method performs head-specific
-    compression by selecting the top-k keys and values across all heads in a layer based
-    on importance scores. Unlike uniform compression, AdaKV allows different heads to
-    retain different numbers of tokens based on their individual importance patterns.
-    
-    The method works by:
-    1. Computing importance scores for all tokens across all heads
-    2. Selecting the globally most important tokens across heads
-    3. Applying a safeguard to ensure each head retains a minimum fraction of tokens
-    4. Masking less important tokens during attention computation
-    
-    Key advantages:
-    - Adapts compression to each head's specific attention patterns
-    - Maintains model performance better than uniform compression
-    - Preserves critical tokens that multiple heads find important
-    
-    This implementation has been reviewed by Yuan Feng, first author of AdaKV.
+    Performs head-specific compression by selecting top-k tokens across all heads
+    based on importance scores. Applies safeguards to ensure each head retains
+    a minimum fraction of tokens. Based on AdaKV (https://arxiv.org/abs/2407.11550).
     """
 
     press: ScorerPress
@@ -41,19 +27,9 @@ class AdaKVPress(BasePress):
     """
     Minimum fraction of KV pairs that each head must retain.
     
-    This safeguard parameter ensures that no attention head is compressed too
-    aggressively, which could severely impact its functionality. Even if a head's
-    tokens receive low global importance scores, it will still retain at least
-    `alpha_safeguard` fraction of its original tokens.
-    
-    Values should be between 0.0 and 1.0:
-    - 0.0: No safeguard (heads could lose all tokens - not recommended)
-    - 0.2: Each head keeps at least 20% of tokens (default)
-    - 0.5: Each head keeps at least 50% of tokens (conservative)
-    
-    Higher values provide more protection for individual heads but may reduce
-    overall compression effectiveness. The default of 0.2 provides a good
-    balance between compression and head functionality preservation.
+    Ensures no attention head is compressed too aggressively. Even if tokens
+    receive low global importance scores, each head retains at least this
+    fraction of its original tokens.
     """
 
     def __post_init__(self):

--- a/kvpress/presses/adakv_press.py
+++ b/kvpress/presses/adakv_press.py
@@ -17,7 +17,9 @@ class AdaKVPress(BasePress):
 
     Performs head-specific compression by selecting top-k tokens across all heads
     based on importance scores. Applies safeguards to ensure each head retains
-    a minimum fraction of tokens. Based on AdaKV (https://arxiv.org/abs/2407.11550).
+    a minimum fraction of tokens.
+
+    Based on AdaKV (https://arxiv.org/abs/2407.11550).
 
     Parameters
     ----------

--- a/kvpress/presses/base_press.py
+++ b/kvpress/presses/base_press.py
@@ -39,11 +39,9 @@ class BasePress:
     
     This class provides the foundation for implementing various key-value cache compression
     techniques. Subclasses must implement the `compress` method to define their specific
-    compression logic. The `forward_hook` method is automatically called after the forward
-    pass of an attention layer to apply compression during the pre-filling phase.
+    compression logic.
     
-    The compression is applied only during pre-filling (not during generation) and handles
-    both quantized and unquantized caches correctly.
+    The compression is applied only during pre-filling (not during generation).
     """
 
     def compress(
@@ -61,8 +59,7 @@ class BasePress:
         Parameters
         ----------
         module : nn.Module
-            The transformer attention layer where compression is applied. Contains layer-specific
-            information like layer index, head dimensions, and configuration.
+            The transformer attention layer where compression is applied.
         hidden_states : torch.Tensor
             Hidden states of the current layer with shape (batch_size, seq_len, hidden_dim).
             These represent the input embeddings to the attention layer.

--- a/kvpress/presses/block_press.py
+++ b/kvpress/presses/block_press.py
@@ -19,18 +19,19 @@ class BlockPress(BasePress):
     processing. Iteratively scores and prunes tokens block by block, maintaining
     a buffer of previously kept tokens for context. Mathematically equivalent
     to global compression when scoring uses only local information.
+    
+    Parameters
+    ----------
+    press : ScorerPress
+        The underlying scoring method used to evaluate token importance within each block.
+    block_size : int, default=256
+        Size of each block for iterative compression.
+        Larger blocks provide more context for scoring but use more memory.
+        Smaller blocks are more memory-efficient but may miss longer-range dependencies.
     """
 
     press: ScorerPress
-    """The underlying scoring method used to evaluate token importance within each block."""
-    
     block_size: int = 256
-    """
-    Size of each block for iterative compression.
-    
-    Larger blocks provide more context for scoring but use more memory.
-    Smaller blocks are more memory-efficient but may miss longer-range dependencies.
-    """
 
     def __post_init__(self):
         assert isinstance(self.press, ScorerPress), "BlockPress requires a ScorerPress"

--- a/kvpress/presses/block_press.py
+++ b/kvpress/presses/block_press.py
@@ -14,12 +14,12 @@ from kvpress.presses.scorer_press import ScorerPress
 class BlockPress(BasePress):
     """
     BlockPress: Block-wise iterative KV cache compression.
-    
+
     Applies compression in fixed-size blocks to manage memory usage during
     processing. Iteratively scores and prunes tokens block by block, maintaining
     a buffer of previously kept tokens for context. Mathematically equivalent
     to global compression when scoring uses only local information.
-    
+
     Parameters
     ----------
     press : ScorerPress

--- a/kvpress/presses/block_press.py
+++ b/kvpress/presses/block_press.py
@@ -15,8 +15,7 @@ class BlockPress(BasePress):
     """
     BlockPress: Block-wise iterative KV cache compression.
 
-    Applies compression in fixed-size blocks to manage memory usage during
-    processing. Iteratively scores and prunes tokens block by block, maintaining
+    Applies compression in fixed-size blocks. Iteratively scores and prunes tokens block by block, maintaining
     a buffer of previously kept tokens for context. Mathematically equivalent
     to global compression when scoring uses only local information.
 
@@ -24,14 +23,12 @@ class BlockPress(BasePress):
     ----------
     press : ScorerPress
         The underlying scoring method used to evaluate token importance within each block.
-    block_size : int, default=256
+    block_size : int, default=128
         Size of each block for iterative compression.
-        Larger blocks provide more context for scoring but use more memory.
-        Smaller blocks are more memory-efficient but may miss longer-range dependencies.
     """
 
     press: ScorerPress
-    block_size: int = 256
+    block_size: int = 128
 
     def __post_init__(self):
         assert isinstance(self.press, ScorerPress), "BlockPress requires a ScorerPress"

--- a/kvpress/presses/block_press.py
+++ b/kvpress/presses/block_press.py
@@ -13,41 +13,23 @@ from kvpress.presses.scorer_press import ScorerPress
 @dataclass
 class BlockPress(BasePress):
     """
-    Block-wise iterative KV cache compression method.
+    BlockPress: Block-wise iterative KV cache compression.
     
-    Simulates block prompt processing as described in KeyDiff (https://arxiv.org/abs/2504.15364).
-    This method segments the input sequence into non-overlapping blocks and applies compression
-    iteratively, maintaining a limited memory overhead for long context inference.
-    
-    The algorithm works by:
-    1. Starting with an empty set of kept tokens
-    2. Processing each block of tokens sequentially
-    3. For each block, scoring all tokens (kept + current block)
-    4. Selecting the top-k tokens to keep for the next iteration
-    5. Continuing until all blocks are processed
-    
-    This approach is particularly effective for very long sequences where global scoring
-    would be computationally expensive or memory-intensive.
+    Applies compression in fixed-size blocks to manage memory usage during
+    processing. Iteratively scores and prunes tokens block by block, maintaining
+    a buffer of previously kept tokens for context. Mathematically equivalent
+    to global compression when scoring uses only local information.
     """
 
     press: ScorerPress
     """The underlying scoring method used to evaluate token importance within each block."""
     
-    block_size: int = 128
+    block_size: int = 256
     """
-    Size of each processing block in tokens.
+    Size of each block for iterative compression.
     
-    Larger blocks:
-    - Provide more context for scoring decisions
-    - Require more memory during processing
-    - May be slower for very long sequences
-    
-    Smaller blocks:
-    - Use less memory per iteration
-    - Process faster but with less context
-    - May make suboptimal compression decisions
-    
-    Typical values range from 64 to 512 tokens depending on available memory and sequence length.
+    Larger blocks provide more context for scoring but use more memory.
+    Smaller blocks are more memory-efficient but may miss longer-range dependencies.
     """
 
     def __post_init__(self):

--- a/kvpress/presses/block_press.py
+++ b/kvpress/presses/block_press.py
@@ -19,6 +19,8 @@ class BlockPress(BasePress):
     a buffer of previously kept tokens for context. Mathematically equivalent
     to global compression when scoring uses only local information.
 
+    Based on BlockPress (https://arxiv.org/abs/2504.15364).
+
     Parameters
     ----------
     press : ScorerPress

--- a/kvpress/presses/chunk_press.py
+++ b/kvpress/presses/chunk_press.py
@@ -20,7 +20,7 @@ class ChunkPress(BasePress):
     may concentrate selection in high-importance regions, ChunkPress ensures
     uniform compression across the entire context by processing each chunk separately.
 
-    This approach was proposed in FINCH (https://direct.mit.edu/tacl/article/doi/10.1162/tacl_a_00716/125280)
+    Based on FINCH (https://direct.mit.edu/tacl/article/doi/10.1162/tacl_a_00716/125280).
 
     Parameters
     ----------

--- a/kvpress/presses/chunk_press.py
+++ b/kvpress/presses/chunk_press.py
@@ -20,12 +20,6 @@ class ChunkPress(BasePress):
     may concentrate selection in high-importance regions, ChunkPress ensures
     uniform compression across the entire context by processing each chunk separately.
     
-    The method works by:
-    1. Dividing the sequence into non-overlapping chunks of fixed size
-    2. Applying the underlying ScorerPress to each chunk independently
-    3. Compressing each chunk according to the specified compression ratio
-    4. Concatenating the compressed chunks to form the final result
-    
     This approach was proposed in FINCH (https://direct.mit.edu/tacl/article/doi/10.1162/tacl_a_00716/125280)
     and offers several advantages:
     - Ensures uniform compression across the entire sequence
@@ -33,42 +27,19 @@ class ChunkPress(BasePress):
     - Maintains balanced representation throughout the context
     - Can improve performance for tasks requiring distributed information
     
-    The independent chunk processing helps maintain the structural integrity
-    of the input by ensuring that each part of the sequence contributes
-    proportionally to the compressed result.
+    Parameters
+    ----------
+    press : ScorerPress
+        The underlying scoring method to apply to each chunk independently.
+        This can be any ScorerPress subclass (e.g., SnapKVPress, KnormPress, etc.).
+    chunk_length : int, default=1024
+        Length of each chunk for independent compression.
+        Larger chunks allow more context but use more memory. Smaller chunks
+        provide more uniform compression but may fragment semantic units.
     """
 
     press: ScorerPress
-    """
-    The underlying scoring method to apply to each chunk independently.
-    
-    This can be any ScorerPress subclass (e.g., SnapKVPress, KnormPress, etc.).
-    The ChunkPress wrapper will apply this method to each chunk separately,
-    ensuring uniform compression across the entire sequence.
-    """
-    
     chunk_length: int = 1024
-    """
-    Length of each chunk for independent compression.
-    
-    The sequence is divided into non-overlapping chunks of this size, and
-    each chunk is compressed independently using the underlying ScorerPress.
-    This parameter controls the granularity of the uniform compression.
-    
-    Larger chunk lengths:
-    - Allow more context within each chunk for scoring decisions
-    - May better preserve local semantic coherence
-    - Reduce the number of chunks to process (more efficient)
-    
-    Smaller chunk lengths:
-    - Provide more fine-grained uniform compression
-    - Ensure more even distribution of selected tokens
-    - May fragment semantic units if too small
-    
-    The default value of 1024 provides a good balance between semantic
-    preservation and uniform compression for most applications. For very
-    long sequences, larger chunk sizes may be more appropriate.
-    """
 
     def __post_init__(self):
         assert isinstance(self.press, ScorerPress), "ChunkPress requires a ScorerPress as input"

--- a/kvpress/presses/chunk_press.py
+++ b/kvpress/presses/chunk_press.py
@@ -13,15 +13,62 @@ from kvpress.presses.scorer_press import ScorerPress
 @dataclass
 class ChunkPress(BasePress):
     """
-    Wrapper class for any ScorerPress.
-    Chunks keys and values into chunks of size chunk_length and compresses each chunk separately.
-    This ensures that the context is compressed uniformly across the entire context.
-    This method was proposed in FINCH: Prompt-guided Key-Value Cache Compression for Large Language Models
-    https://direct.mit.edu/tacl/article/doi/10.1162/tacl_a_00716/125280
+    ChunkPress: Uniform compression through independent chunk processing.
+    
+    This wrapper enhances any ScorerPress by applying compression independently
+    to fixed-size chunks of the sequence. Unlike global compression methods that
+    may concentrate selection in high-importance regions, ChunkPress ensures
+    uniform compression across the entire context by processing each chunk separately.
+    
+    The method works by:
+    1. Dividing the sequence into non-overlapping chunks of fixed size
+    2. Applying the underlying ScorerPress to each chunk independently
+    3. Compressing each chunk according to the specified compression ratio
+    4. Concatenating the compressed chunks to form the final result
+    
+    This approach was proposed in FINCH (https://direct.mit.edu/tacl/article/doi/10.1162/tacl_a_00716/125280)
+    and offers several advantages:
+    - Ensures uniform compression across the entire sequence
+    - Prevents over-concentration of selected tokens in specific regions
+    - Maintains balanced representation throughout the context
+    - Can improve performance for tasks requiring distributed information
+    
+    The independent chunk processing helps maintain the structural integrity
+    of the input by ensuring that each part of the sequence contributes
+    proportionally to the compressed result.
     """
 
     press: ScorerPress
+    """
+    The underlying scoring method to apply to each chunk independently.
+    
+    This can be any ScorerPress subclass (e.g., SnapKVPress, KnormPress, etc.).
+    The ChunkPress wrapper will apply this method to each chunk separately,
+    ensuring uniform compression across the entire sequence.
+    """
+    
     chunk_length: int = 1024
+    """
+    Length of each chunk for independent compression.
+    
+    The sequence is divided into non-overlapping chunks of this size, and
+    each chunk is compressed independently using the underlying ScorerPress.
+    This parameter controls the granularity of the uniform compression.
+    
+    Larger chunk lengths:
+    - Allow more context within each chunk for scoring decisions
+    - May better preserve local semantic coherence
+    - Reduce the number of chunks to process (more efficient)
+    
+    Smaller chunk lengths:
+    - Provide more fine-grained uniform compression
+    - Ensure more even distribution of selected tokens
+    - May fragment semantic units if too small
+    
+    The default value of 1024 provides a good balance between semantic
+    preservation and uniform compression for most applications. For very
+    long sequences, larger chunk sizes may be more appropriate.
+    """
 
     def __post_init__(self):
         assert isinstance(self.press, ScorerPress), "ChunkPress requires a ScorerPress as input"

--- a/kvpress/presses/chunk_press.py
+++ b/kvpress/presses/chunk_press.py
@@ -14,19 +14,19 @@ from kvpress.presses.scorer_press import ScorerPress
 class ChunkPress(BasePress):
     """
     ChunkPress: Uniform compression through independent chunk processing.
-    
+
     This wrapper enhances any ScorerPress by applying compression independently
     to fixed-size chunks of the sequence. Unlike global compression methods that
     may concentrate selection in high-importance regions, ChunkPress ensures
     uniform compression across the entire context by processing each chunk separately.
-    
+
     This approach was proposed in FINCH (https://direct.mit.edu/tacl/article/doi/10.1162/tacl_a_00716/125280)
     and offers several advantages:
     - Ensures uniform compression across the entire sequence
     - Prevents over-concentration of selected tokens in specific regions
     - Maintains balanced representation throughout the context
     - Can improve performance for tasks requiring distributed information
-    
+
     Parameters
     ----------
     press : ScorerPress

--- a/kvpress/presses/chunk_press.py
+++ b/kvpress/presses/chunk_press.py
@@ -21,21 +21,13 @@ class ChunkPress(BasePress):
     uniform compression across the entire context by processing each chunk separately.
 
     This approach was proposed in FINCH (https://direct.mit.edu/tacl/article/doi/10.1162/tacl_a_00716/125280)
-    and offers several advantages:
-    - Ensures uniform compression across the entire sequence
-    - Prevents over-concentration of selected tokens in specific regions
-    - Maintains balanced representation throughout the context
-    - Can improve performance for tasks requiring distributed information
 
     Parameters
     ----------
     press : ScorerPress
         The underlying scoring method to apply to each chunk independently.
-        This can be any ScorerPress subclass (e.g., SnapKVPress, KnormPress, etc.).
     chunk_length : int, default=1024
         Length of each chunk for independent compression.
-        Larger chunks allow more context but use more memory. Smaller chunks
-        provide more uniform compression but may fragment semantic units.
     """
 
     press: ScorerPress

--- a/kvpress/presses/chunkkv_press.py
+++ b/kvpress/presses/chunkkv_press.py
@@ -14,15 +14,15 @@ from kvpress.presses.scorer_press import ScorerPress
 class ChunkKVPress(BasePress):
     """
     ChunkKV: Semantic-preserving compression with chunk-wise token selection.
-    
+
     Enhances any ScorerPress by applying chunk-wise token selection instead of
     global selection. Computes global importance scores, then selects tokens
     chunk by chunk to preserve semantic coherence within local contexts.
     Based on ChunkKV (https://arxiv.org/abs/2502.00299).
-    
+
     Prevents over-concentration of selected tokens in specific regions and
     maintains balanced representation across the entire sequence.
-    
+
     Parameters
     ----------
     press : ScorerPress

--- a/kvpress/presses/chunkkv_press.py
+++ b/kvpress/presses/chunkkv_press.py
@@ -20,14 +20,10 @@ class ChunkKVPress(BasePress):
     chunk by chunk to preserve semantic coherence within local contexts.
     Based on ChunkKV (https://arxiv.org/abs/2502.00299).
 
-    Prevents over-concentration of selected tokens in specific regions and
-    maintains balanced representation across the entire sequence.
-
     Parameters
     ----------
     press : ScorerPress
         The underlying scoring method used to compute global importance scores.
-        Can be any ScorerPress subclass (e.g., SnapKVPress, KnormPress, etc.).
     chunk_length : int, default=20
         Length of each chunk for token selection.
         Sequence is divided into chunks of this size, with tokens selected

--- a/kvpress/presses/chunkkv_press.py
+++ b/kvpress/presses/chunkkv_press.py
@@ -18,6 +18,7 @@ class ChunkKVPress(BasePress):
     Enhances any ScorerPress by applying chunk-wise token selection instead of
     global selection. Computes global importance scores, then selects tokens
     chunk by chunk to preserve semantic coherence within local contexts.
+
     Based on ChunkKV (https://arxiv.org/abs/2502.00299).
 
     Parameters

--- a/kvpress/presses/chunkkv_press.py
+++ b/kvpress/presses/chunkkv_press.py
@@ -15,58 +15,27 @@ class ChunkKVPress(BasePress):
     """
     ChunkKV: Semantic-preserving compression with chunk-wise token selection.
     
-    Based on ChunkKV (https://arxiv.org/abs/2502.00299), this method enhances any
-    ScorerPress by applying chunk-wise token selection instead of global selection.
-    The approach first computes global importance scores, then selects tokens
+    Enhances any ScorerPress by applying chunk-wise token selection instead of
+    global selection. Computes global importance scores, then selects tokens
     chunk by chunk to preserve semantic coherence within local contexts.
+    Based on ChunkKV (https://arxiv.org/abs/2502.00299).
     
-    The method works by:
-    1. Computing global importance scores using the underlying ScorerPress
-    2. Dividing the sequence into fixed-size chunks
-    3. For each chunk, selecting the most important tokens based on global scores
-    4. Ensuring each chunk contributes proportionally to the final compressed sequence
+    Prevents over-concentration of selected tokens in specific regions and
+    maintains balanced representation across the entire sequence.
     
-    This approach offers several advantages:
-    - Preserves local semantic coherence within chunks
-    - Prevents over-concentration of selected tokens in specific regions
-    - Maintains balanced representation across the entire sequence
-    - Can improve performance compared to pure global selection
-    
-    The chunk-wise selection helps maintain the semantic structure of the input
-    by ensuring that important tokens are distributed throughout the sequence
-    rather than clustered in high-importance regions.
+    Parameters
+    ----------
+    press : ScorerPress
+        The underlying scoring method used to compute global importance scores.
+        Can be any ScorerPress subclass (e.g., SnapKVPress, KnormPress, etc.).
+    chunk_length : int, default=20
+        Length of each chunk for token selection.
+        Sequence is divided into chunks of this size, with tokens selected
+        proportionally from each chunk based on global importance scores.
     """
 
     press: ScorerPress
-    """
-    The underlying scoring method used to compute global importance scores.
-    
-    This can be any ScorerPress subclass (e.g., SnapKVPress, KnormPress, etc.).
-    The ChunkKV wrapper will use this method to compute importance scores for
-    all tokens, then apply chunk-wise selection based on these scores.
-    """
-    
     chunk_length: int = 20
-    """
-    Length of each chunk for token selection.
-    
-    The sequence is divided into non-overlapping chunks of this size, and tokens
-    are selected proportionally from each chunk based on their global importance
-    scores. This parameter controls the granularity of the chunk-wise selection.
-    
-    Larger chunk lengths:
-    - Allow more flexibility in token selection within each chunk
-    - May better preserve local semantic coherence
-    - Reduce the number of chunks to process
-    
-    Smaller chunk lengths:
-    - Provide more fine-grained control over token distribution
-    - Ensure more uniform selection across the sequence
-    - May fragment semantic units if too small
-    
-    The default value of 20 provides a good balance between semantic preservation
-    and uniform token distribution for most applications.
-    """
 
     def __post_init__(self):
         assert isinstance(self.press, ScorerPress), "ChunkKVPress requires a ScorerPress as input"

--- a/kvpress/presses/composed_press.py
+++ b/kvpress/presses/composed_press.py
@@ -26,15 +26,16 @@ class ComposedPress(BasePress):
     ```
     
     Cannot include ObservedAttentionPress or AdaKVPress due to implementation constraints.
+    
+    Parameters
+    ----------
+    presses : list[BasePress]
+        List of compression methods to apply sequentially.
+        Methods are applied in order, with each operating on the compressed output
+        of the previous method. Final compression ratio is the product of all ratios.
     """
 
     presses: list[BasePress]
-    """
-    List of compression methods to apply sequentially.
-    
-    Methods are applied in order, with each operating on the compressed output
-    of the previous method. Final compression ratio is the product of all ratios.
-    """
 
     def __post_init__(self):
         self.compression_ratio = None

--- a/kvpress/presses/composed_press.py
+++ b/kvpress/presses/composed_press.py
@@ -13,53 +13,27 @@ class ComposedPress(BasePress):
     """
     Composed compression: Chain multiple compression methods sequentially.
     
-    This class allows combining multiple compression methods to achieve more
-    sophisticated compression strategies. The methods are applied sequentially,
-    with each method operating on the output of the previous one.
+    Applies multiple compression methods in sequence, with each method operating
+    on the output of the previous one. Useful for combining complementary approaches
+    like sequence + dimension compression.
     
-    The composition is particularly useful for:
-    - Combining complementary compression approaches (e.g., sequence + dimension compression)
-    - Creating multi-stage compression pipelines
-    - Experimenting with hybrid compression strategies
-    
-    Example usage:
+    Example:
     ```python
-    # Combine sequence compression with dimensional compression
     press = ComposedPress([
-        SnapKVPress(compression_ratio=0.3),  # First reduce sequence length
-        ThinKPress(key_channel_compression_ratio=0.2)  # Then reduce key dimensions
-    ])
-    
-    # Multi-stage sequence compression
-    press = ComposedPress([
-        StreamingLLMPress(compression_ratio=0.4, n_sink=4),  # Window-based pruning
-        KnormPress(compression_ratio=0.2)  # Further refinement with norm-based pruning
+        SnapKVPress(compression_ratio=0.3),
+        ThinKPress(key_channel_compression_ratio=0.2)
     ])
     ```
     
-    The effective compression ratio is the product of all individual ratios.
-    For example, two methods with 0.5 compression ratio each result in 0.75
-    overall compression (keeping 25% of original tokens).
-    
-    Limitations:
-    - Cannot include ObservedAttentionPress or AdaKVPress due to implementation constraints
-    - Order of composition matters and affects final results
-    - Computational overhead increases with number of composed methods
+    Cannot include ObservedAttentionPress or AdaKVPress due to implementation constraints.
     """
 
     presses: list[BasePress]
     """
     List of compression methods to apply sequentially.
     
-    The methods are applied in the order specified, with each method operating
-    on the compressed output of the previous method. The list should contain
-    BasePress instances that are compatible with sequential composition.
-    
-    Restrictions:
-    - Cannot include ObservedAttentionPress (requires specific attention handling)
-    - Cannot include AdaKVPress (requires head-wise masking incompatible with composition)
-    
-    The final compression ratio will be the product of all individual compression ratios.
+    Methods are applied in order, with each operating on the compressed output
+    of the previous method. Final compression ratio is the product of all ratios.
     """
 
     def __post_init__(self):

--- a/kvpress/presses/composed_press.py
+++ b/kvpress/presses/composed_press.py
@@ -11,10 +11,56 @@ from kvpress.presses.observed_attention_press import ObservedAttentionPress
 @dataclass
 class ComposedPress(BasePress):
     """
-    Chain multiple presses together to create a composed press
+    Composed compression: Chain multiple compression methods sequentially.
+    
+    This class allows combining multiple compression methods to achieve more
+    sophisticated compression strategies. The methods are applied sequentially,
+    with each method operating on the output of the previous one.
+    
+    The composition is particularly useful for:
+    - Combining complementary compression approaches (e.g., sequence + dimension compression)
+    - Creating multi-stage compression pipelines
+    - Experimenting with hybrid compression strategies
+    
+    Example usage:
+    ```python
+    # Combine sequence compression with dimensional compression
+    press = ComposedPress([
+        SnapKVPress(compression_ratio=0.3),  # First reduce sequence length
+        ThinKPress(key_channel_compression_ratio=0.2)  # Then reduce key dimensions
+    ])
+    
+    # Multi-stage sequence compression
+    press = ComposedPress([
+        StreamingLLMPress(compression_ratio=0.4, n_sink=4),  # Window-based pruning
+        KnormPress(compression_ratio=0.2)  # Further refinement with norm-based pruning
+    ])
+    ```
+    
+    The effective compression ratio is the product of all individual ratios.
+    For example, two methods with 0.5 compression ratio each result in 0.75
+    overall compression (keeping 25% of original tokens).
+    
+    Limitations:
+    - Cannot include ObservedAttentionPress or AdaKVPress due to implementation constraints
+    - Order of composition matters and affects final results
+    - Computational overhead increases with number of composed methods
     """
 
     presses: list[BasePress]
+    """
+    List of compression methods to apply sequentially.
+    
+    The methods are applied in the order specified, with each method operating
+    on the compressed output of the previous method. The list should contain
+    BasePress instances that are compatible with sequential composition.
+    
+    Restrictions:
+    - Cannot include ObservedAttentionPress (requires specific attention handling)
+    - Cannot include AdaKVPress (requires head-wise masking incompatible with composition)
+    
+    The final compression ratio will be the product of all individual compression ratios.
+    """
 
     def __post_init__(self):
         self.compression_ratio = None

--- a/kvpress/presses/composed_press.py
+++ b/kvpress/presses/composed_press.py
@@ -25,7 +25,7 @@ class ComposedPress(BasePress):
     ])
     ```
 
-    Cannot include ObservedAttentionPress or AdaKVPress due to implementation constraints.
+    ObservedAttentionPress or AdaKVPress are currently not supported.
 
     Parameters
     ----------

--- a/kvpress/presses/composed_press.py
+++ b/kvpress/presses/composed_press.py
@@ -12,11 +12,11 @@ from kvpress.presses.observed_attention_press import ObservedAttentionPress
 class ComposedPress(BasePress):
     """
     Composed compression: Chain multiple compression methods sequentially.
-    
+
     Applies multiple compression methods in sequence, with each method operating
     on the output of the previous one. Useful for combining complementary approaches
     like sequence + dimension compression.
-    
+
     Example:
     ```python
     press = ComposedPress([
@@ -24,9 +24,9 @@ class ComposedPress(BasePress):
         ThinKPress(key_channel_compression_ratio=0.2)
     ])
     ```
-    
+
     Cannot include ObservedAttentionPress or AdaKVPress due to implementation constraints.
-    
+
     Parameters
     ----------
     presses : list[BasePress]

--- a/kvpress/presses/criticalkv_press.py
+++ b/kvpress/presses/criticalkv_press.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 class CriticalKVPress(ScorerPress):
     """
     CriticalKV: Two-stage compression with output projection weighting.
-    
+
     Enhances existing scoring methods by rescaling scores using the L1 norm
     of output projection applied to values (Wo @ values). Provides more accurate
     importance estimation by considering actual output contributions.
@@ -27,7 +27,7 @@ class CriticalKVPress(ScorerPress):
     def __init__(self, press: ScorerPress, epsilon: float = 1e-4, first_stage_ratio: float = 0.5):
         """
         Initialize CriticalKV compression method.
-        
+
         Parameters
         ----------
         press : ScorerPress
@@ -96,12 +96,12 @@ class CriticalKVPress(ScorerPress):
 class CriticalAdaKVPress(BasePress):
     """
     CriticalAdaKV: Combined two-stage compression with adaptive head-wise selection.
-    
+
     Combines output projection weighting from CriticalKV with adaptive head-wise
     compression from AdaKV. Provides both accurate importance estimation and
     head-specific compression adaptation.
     Based on CriticalAdaKV (https://arxiv.org/abs/2502.03805).
-    
+
     Parameters
     ----------
     press : ScorerPress

--- a/kvpress/presses/criticalkv_press.py
+++ b/kvpress/presses/criticalkv_press.py
@@ -101,20 +101,24 @@ class CriticalAdaKVPress(BasePress):
     compression from AdaKV. Provides both accurate importance estimation and
     head-specific compression adaptation.
     Based on CriticalAdaKV (https://arxiv.org/abs/2502.03805).
+    
+    Parameters
+    ----------
+    press : ScorerPress
+        The underlying scoring method used to evaluate token importance.
+    alpha_safeguard : float, default=0.20
+        Minimum fraction of KV pairs that each head must retain.
+    epsilon : float, default=1e-4
+        Small value for numerical stability in score rescaling.
+    first_stage_ratio : float, default=0.5
+        Fraction of compression budget allocated to first stage selection.
     """
 
     press: ScorerPress
-    """The underlying scoring method used to evaluate token importance."""
-    
     alpha_safeguard: float = 0.20
-    """Minimum fraction of KV pairs that each head must retain."""
-    
     epsilon: float = 1e-4
-    """Small value for numerical stability in score rescaling."""
-    
     first_stage_ratio: float = 0.5
-    """Fraction of compression budget allocated to first stage selection."""
-    
+
     def __post_init__(self):
         assert 0 <= self.alpha_safeguard <= 1, "alpha_safeguard should be in 0, 1]"
         assert isinstance(self.press, ScorerPress), "CriticalAdaKVPress requires a ScorerPress as input"

--- a/kvpress/presses/criticalkv_press.py
+++ b/kvpress/presses/criticalkv_press.py
@@ -14,34 +14,31 @@ from kvpress.presses.scorer_press import ScorerPress
 logger = logging.getLogger(__name__)
 
 
+@dataclass
 class CriticalKVPress(ScorerPress):
     """
     CriticalKV: Two-stage compression with output projection weighting.
 
     Enhances existing scoring methods by rescaling scores using the L1 norm
-    of output projection applied to values (Wo @ values). Provides more accurate
-    importance estimation by considering actual output contributions.
+    of output projection applied to values (Wo @ values).
     Based on CriticalKV (https://arxiv.org/abs/2502.03805).
+
+    Parameters
+    ----------
+    press : ScorerPress
+        Base scoring method to enhance with output projection weighting.
+    epsilon : float, default=1e-4
+        Small value for numerical stability in score rescaling.
+    first_stage_ratio : float, default=0.5
+        Fraction of compression budget allocated to first stage selection.
+        Remaining budget used in second stage with output projection weighting.
     """
 
-    def __init__(self, press: ScorerPress, epsilon: float = 1e-4, first_stage_ratio: float = 0.5):
-        """
-        Initialize CriticalKV compression method.
+    press: ScorerPress = None
+    epsilon: float = 1e-4
+    first_stage_ratio: float = 0.5
 
-        Parameters
-        ----------
-        press : ScorerPress
-            Base scoring method to enhance with output projection weighting.
-        epsilon : float, default=1e-4
-            Small value for numerical stability in score rescaling.
-        first_stage_ratio : float, default=0.5
-            Fraction of compression budget allocated to first stage selection.
-            Remaining budget used in second stage with output projection weighting.
-        """
-        self.press = press
-        self.epsilon = epsilon
-        self.first_stage_ratio = first_stage_ratio
-
+    def __post_init__(self):
         assert isinstance(self.press, ScorerPress), "CriticalKVPress requires a ScorerPress as input"
         if isinstance(self.press, ExpectedAttentionPress) and self.press.use_vnorm:
             logger.warning("use_vnorm should be disabled for CriticalKVPress")
@@ -114,7 +111,7 @@ class CriticalAdaKVPress(BasePress):
         Fraction of compression budget allocated to first stage selection.
     """
 
-    press: ScorerPress
+    press: ScorerPress = None
     alpha_safeguard: float = 0.20
     epsilon: float = 1e-4
     first_stage_ratio: float = 0.5

--- a/kvpress/presses/criticalkv_press.py
+++ b/kvpress/presses/criticalkv_press.py
@@ -21,6 +21,7 @@ class CriticalKVPress(ScorerPress):
 
     Enhances existing scoring methods by rescaling scores using the L1 norm
     of output projection applied to values (Wo @ values).
+
     Based on CriticalKV (https://arxiv.org/abs/2502.03805).
 
     Parameters
@@ -97,6 +98,7 @@ class CriticalAdaKVPress(BasePress):
     Combines output projection weighting from CriticalKV with adaptive head-wise
     compression from AdaKV. Provides both accurate importance estimation and
     head-specific compression adaptation.
+
     Based on CriticalAdaKV (https://arxiv.org/abs/2502.03805).
 
     Parameters

--- a/kvpress/presses/criticalkv_press.py
+++ b/kvpress/presses/criticalkv_press.py
@@ -16,18 +16,54 @@ logger = logging.getLogger(__name__)
 
 class CriticalKVPress(ScorerPress):
     """
-    CriticalKV (https://arxiv.org/abs/2502.03805) rescales the scores of a ScorerPress by
-    the L1 norm of Wo @ values
+    CriticalKV: Two-stage compression with output projection weighting.
+    
+    Based on CriticalKV (https://arxiv.org/abs/2502.03805), this method enhances
+    existing scoring methods by rescaling their scores using the L1 norm of the
+    output projection applied to values (Wo @ values). This provides a more
+    accurate estimate of each token's contribution to the final output.
+    
+    The method works in two stages:
+    1. First stage: Select a subset of tokens using the base scoring method
+    2. Second stage: Rescale all scores by their output projection magnitude
+    3. Final selection: Combine both stages to make final compression decisions
+    
+    This approach is particularly effective because:
+    - It considers not just attention patterns but actual output contributions
+    - The two-stage process balances different importance signals
+    - It can improve any existing scoring method as a wrapper
     """
 
     def __init__(self, press: ScorerPress, epsilon: float = 1e-4, first_stage_ratio: float = 0.5):
+        """
+        Initialize CriticalKV compression method.
+        
+        Parameters
+        ----------
+        press : ScorerPress
+            The base scoring method to enhance with output projection weighting.
+        epsilon : float, default=1e-4
+            Small value added for numerical stability when computing score rescaling.
+            Prevents division by zero and stabilizes gradients during computation.
+        first_stage_ratio : float, default=0.5
+            Fraction of the compression budget allocated to the first stage selection.
+            
+            The first stage selects `compression_ratio * first_stage_ratio * seq_len`
+            tokens using the base scoring method. The remaining budget is used in
+            the second stage with output projection weighting.
+            
+            Values should be between 0.0 and 1.0:
+            - 0.0: Only use output projection weighting (skip first stage)
+            - 0.5: Balance both stages equally (default)
+            - 1.0: Only use base scoring method (skip output weighting)
+        """
         self.press = press
         self.epsilon = epsilon
         self.first_stage_ratio = first_stage_ratio
 
-        assert isinstance(self.press, ScorerPress), "CriticalAdaKVPress requires a ScorerPress as input"
+        assert isinstance(self.press, ScorerPress), "CriticalKVPress requires a ScorerPress as input"
         if isinstance(self.press, ExpectedAttentionPress) and self.press.use_vnorm:
-            logger.warning("use_vnorm should be disabled for CriticalAdaKVPress")
+            logger.warning("use_vnorm should be disabled for CriticalKVPress")
 
     @property
     def compression_ratio(self):
@@ -78,15 +114,59 @@ class CriticalKVPress(ScorerPress):
 @dataclass
 class CriticalAdaKVPress(BasePress):
     """
-    CriticalAdaKV (https://arxiv.org/abs/2502.03805) rescales the scores of a ScorerPress by
-    the L1 norm of Wo @ values and combines it with AdaKV (https://arxiv.org/abs/2407.11550).
+    CriticalAdaKV: Combined two-stage compression with adaptive head-wise selection.
+    
+    Based on CriticalAdaKV (https://arxiv.org/abs/2502.03805), this method combines
+    the output projection weighting from CriticalKV with the adaptive head-wise
+    compression from AdaKV. This provides both accurate importance estimation
+    and head-specific compression adaptation.
+    
+    The method works by:
+    1. Computing base importance scores using the underlying scorer
+    2. Applying two-stage selection with output projection weighting
+    3. Performing adaptive head-wise compression with safeguards
+    4. Masking less important tokens during attention computation
+    
+    This combines the best of both approaches:
+    - CriticalKV's accurate output-based importance estimation
+    - AdaKV's adaptive head-wise compression strategy
+    - Safeguards to protect individual attention heads
     """
 
     press: ScorerPress
+    """The underlying scoring method used to evaluate token importance."""
+    
     alpha_safeguard: float = 0.20
+    """
+    Minimum fraction of KV pairs that each head must retain.
+    
+    This safeguard parameter ensures that no attention head is compressed too
+    aggressively, which could severely impact its functionality. Even if a head's
+    tokens receive low global importance scores, it will still retain at least
+    `alpha_safeguard` fraction of its original tokens.
+    
+    See AdaKVPress.alpha_safeguard for detailed description.
+    """
+    
     epsilon: float = 1e-4
+    """
+    Small value added for numerical stability when computing score rescaling.
+    
+    This prevents division by zero and stabilizes gradients during the computation
+    of output projection magnitudes. Should be a small positive value.
+    """
+    
     first_stage_ratio: float = 0.5
-
+    """
+    Fraction of the compression budget allocated to the first stage selection.
+    
+    The first stage selects tokens using the base scoring method, while the
+    second stage applies output projection weighting. This parameter controls
+    the balance between these two selection criteria.
+    
+    See CriticalKVPress.__init__ for detailed description of this parameter.
+    """
+    
     def __post_init__(self):
         assert 0 <= self.alpha_safeguard <= 1, "alpha_safeguard should be in 0, 1]"
         assert isinstance(self.press, ScorerPress), "CriticalAdaKVPress requires a ScorerPress as input"

--- a/kvpress/presses/criticalkv_press.py
+++ b/kvpress/presses/criticalkv_press.py
@@ -44,8 +44,8 @@ class CriticalKVPress(ScorerPress):
         if isinstance(self.press, ExpectedAttentionPress) and self.press.use_vnorm:
             logger.warning("use_vnorm should be disabled for CriticalKVPress")
 
-    @property
-    def compression_ratio(self):
+    @property  # type: ignore[misc]
+    def compression_ratio(self):  #
         return self.press.compression_ratio
 
     @compression_ratio.setter
@@ -106,7 +106,7 @@ class CriticalAdaKVPress(BasePress):
     press : ScorerPress
         The underlying scoring method used to evaluate token importance.
     alpha_safeguard : float, default=0.20
-        Minimum fraction of KV pairs that each head must retain.
+        Minimum fraction of KV pairs that each head must retain. (see AdaKVPress)
     epsilon : float, default=1e-4
         Small value for numerical stability in score rescaling.
     first_stage_ratio : float, default=0.5

--- a/kvpress/presses/duo_attention_press.py
+++ b/kvpress/presses/duo_attention_press.py
@@ -32,24 +32,98 @@ cache = LRUCache(maxsize=128)
 @dataclass
 class DuoAttentionPress(BasePress):
     """
-    Implements DuoAttention (https://arxiv.org/abs/2410.10819)
-
-    Splits attention heads into two types:
-    - Retrieval heads: use the full KV cache
-    - Streaming heads: use only sink and recent tokens.
-    The higher the head_compression_ratio, the more streaming heads are used.
-
-    Head classification is based on scores.
-    - If on_the_fly_scoring=False, scores are loaded from https://github.com/mit-han-lab/duo-attention/
-    - (experimental) If on_the_fly_scoring=True, scores are computed using duo_attention_on_the_fly
+    DuoAttention: Hybrid attention with retrieval and streaming heads.
+    
+    Based on DuoAttention (https://arxiv.org/abs/2410.10819), this method splits
+    attention heads into two complementary types to optimize both memory usage
+    and attention quality:
+    
+    - **Retrieval heads**: Use the full KV cache for comprehensive attention
+    - **Streaming heads**: Use only sink tokens + recent tokens (like StreamingLLM)
+    
+    This hybrid approach leverages the observation that different attention heads
+    have different attention patterns and memory requirements. Some heads benefit
+    from full context (retrieval), while others work well with limited context (streaming).
+    
+    The method works by:
+    1. Loading pre-computed attention patterns for the specific model
+    2. Classifying heads as retrieval or streaming based on these patterns
+    3. Applying different compression strategies per head type
+    4. Using head_compression_ratio to control the retrieval/streaming split
+    
+    Key advantages:
+    - Maintains high attention quality for heads that need full context
+    - Reduces memory usage for heads that work well with limited context
+    - Model-specific optimization based on learned attention patterns
+    - Balances performance and efficiency automatically
+    
+    The attention patterns are pre-computed and cached for supported models.
+    If patterns are not available for a model, the method falls back to
+    on-the-fly computation using random samples.
     """
 
     head_compression_ratio: float = 0.0
+    """
+    Fraction of attention heads to convert to streaming heads.
+    
+    This parameter controls the balance between retrieval and streaming heads:
+    - 0.0: All heads are retrieval heads (full KV cache, no compression)
+    - 0.5: 50% streaming heads, 50% retrieval heads (balanced approach)
+    - 0.8: 80% streaming heads, 20% retrieval heads (aggressive compression)
+    - 1.0: All heads are streaming heads (maximum compression)
+    
+    Higher values result in more memory savings but may reduce attention quality
+    for tasks requiring long-range dependencies. The optimal value depends on
+    the specific model and use case.
+    
+    The heads are selected for streaming based on pre-computed attention patterns
+    that identify which heads work well with limited context.
+    """
+    
     on_the_fly_scoring: bool = False
+    """
+    Whether to compute attention patterns on the fly using random samples.
+    
+    If True, the method will compute attention patterns using random samples
+    instead of loading pre-computed patterns. This can be useful for models
+    that are not supported by the pre-computed patterns.
+    
+    Note that on-the-fly computation can be slower and may not provide the same
+    level of optimization as pre-computed patterns.
+    """
+    
     compression_ratio_: float = field(init=False, default=None)
+    """
+    The actual compression ratio achieved by the DuoAttentionPress.
+    
+    This value is computed during the forward pass and represents the fraction
+    of attention heads that are converted to streaming heads.
+    """
+    
     recent_size: int = field(init=False, default=None)
+    """
+    The size of the recent token window for streaming heads.
+    
+    Streaming heads use only sink tokens (first few tokens) plus the most recent
+    `recent_size` tokens. This value is determined based on the pre-computed
+    attention patterns or on-the-fly computation.
+    """
+    
     sink_size: int = field(init=False, default=None)
+    """
+    The number of initial tokens to preserve for streaming heads (sink tokens).
+    
+    Similar to StreamingLLM, streaming heads always preserve the first `sink_size`
+    tokens regardless of the window size. These act as "attention sinks" that
+    help maintain model stability.
+    """
+    
     streaming_mask: torch.Tensor = field(init=False, default=None)
+    """
+    A binary mask indicating which attention heads are streaming heads.
+    
+    This mask is used to apply different compression strategies per head type.
+    """
 
     def __post_init_from_model__(self, model):
         """

--- a/kvpress/presses/duo_attention_press.py
+++ b/kvpress/presses/duo_attention_press.py
@@ -34,10 +34,12 @@ class DuoAttentionPress(BasePress):
     """
     DuoAttention: Hybrid attention with retrieval and streaming heads.
 
-    Splits attention heads into two types: retrieval heads (use full KV cache) and
-    streaming heads (use only sink + recent tokens). Different heads have different
-    attention patterns - some benefit from full context while others work well with
-    limited context. Based on DuoAttention (https://arxiv.org/abs/2410.10819).
+    Splits attention heads into two types:
+        - retrieval heads (use full KV cache) and
+        - streaming heads (use only sink + recent tokens).
+    Different heads have different attention patterns - some benefit from full context while others work well with
+    limited context.
+    Based on DuoAttention (https://arxiv.org/abs/2410.10819).
 
     Uses pre-computed attention patterns for supported models, falls back to
     on-the-fly computation for unsupported models.

--- a/kvpress/presses/duo_attention_press.py
+++ b/kvpress/presses/duo_attention_press.py
@@ -39,10 +39,11 @@ class DuoAttentionPress(BasePress):
         - streaming heads (use only sink + recent tokens).
     Different heads have different attention patterns - some benefit from full context while others work well with
     limited context.
-    Based on DuoAttention (https://arxiv.org/abs/2410.10819).
 
     Uses pre-computed attention patterns for supported models, falls back to
     on-the-fly computation for unsupported models.
+
+    Based on DuoAttention (https://arxiv.org/abs/2410.10819).
 
     Parameters
     ----------

--- a/kvpress/presses/expected_attention_press.py
+++ b/kvpress/presses/expected_attention_press.py
@@ -8,10 +8,10 @@ from dataclasses import dataclass
 import torch
 from torch import nn
 from torch.nn import functional as F
-from transformers.models.llama.modeling_llama import repeat_kv
-from transformers.models.qwen3.modeling_qwen3 import Qwen3Attention
 from transformers.models.gemma3.modeling_gemma3 import Gemma3Attention
+from transformers.models.llama.modeling_llama import repeat_kv
 from transformers.models.phi3.modeling_phi3 import Phi3Attention
+from transformers.models.qwen3.modeling_qwen3 import Qwen3Attention
 
 from kvpress.presses.scorer_press import ScorerPress
 
@@ -20,11 +20,11 @@ from kvpress.presses.scorer_press import ScorerPress
 class ExpectedAttentionPress(ScorerPress):
     """
     Expected attention-based KV cache compression.
-    
+
     Computes importance scores based on expected attention that future queries
     will pay to current key-value pairs. Uses statistical modeling of query
     patterns and RoPE rotation matrices to predict future attention.
-    
+
     Parameters
     ----------
     compression_ratio : float, default=0.0

--- a/kvpress/presses/expected_attention_press.py
+++ b/kvpress/presses/expected_attention_press.py
@@ -24,40 +24,35 @@ class ExpectedAttentionPress(ScorerPress):
     Computes importance scores based on expected attention that future queries
     will pay to current key-value pairs. Uses statistical modeling of query
     patterns and RoPE rotation matrices to predict future attention.
+    
+    Parameters
+    ----------
+    compression_ratio : float, default=0.0
+        Fraction of key-value pairs to remove during compression.
+    n_future_positions : int, default=512
+        Number of future positions to consider when computing expected attention.
+    n_sink : int, default=4
+        Number of initial tokens to exclude from compression (sink tokens).
+        Preserves first few tokens due to "sink attention" phenomenon where models
+        assign high attention to early tokens regardless of semantic importance.
+    use_covariance : bool, default=True
+        Whether to include covariance information in expected attention computation.
+        When True, uses both mean and covariance of query distributions for more
+        accurate but computationally expensive scoring. When False, uses only mean.
+    use_vnorm : bool, default=True
+        Whether to rescale scores using value vector norms.
+        Rescales expected attention scores by L2 norm of corresponding value vectors:
+        (scores + epsilon) * ||V||₂. Accounts for magnitude of attended information.
+    epsilon : float, default=0.0
+        Small constant added to scores before value norm rescaling for numerical stability.
     """
 
     compression_ratio: float = 0.0
-    """Fraction of key-value pairs to remove during compression."""
-    
     n_future_positions: int = 512
-    """Number of future positions to consider when computing expected attention."""
-    
     n_sink: int = 4
-    """
-    Number of initial tokens to exclude from compression (sink tokens).
-    
-    Preserves first few tokens due to "sink attention" phenomenon where models
-    assign high attention to early tokens regardless of semantic importance.
-    """
-    
     use_covariance: bool = True
-    """
-    Whether to include covariance information in expected attention computation.
-    
-    When True, uses both mean and covariance of query distributions for more
-    accurate but computationally expensive scoring. When False, uses only mean.
-    """
-    
     use_vnorm: bool = True
-    """
-    Whether to rescale scores using value vector norms.
-    
-    Rescales expected attention scores by L2 norm of corresponding value vectors:
-    (scores + epsilon) * ||V||₂. Accounts for magnitude of attended information.
-    """
-    
     epsilon: float = 0.0
-    """Small constant added to scores before value norm rescaling for numerical stability."""
 
     def get_query_statistics(self, module: nn.Module, hidden_states: torch.Tensor):
         """

--- a/kvpress/presses/expected_attention_press.py
+++ b/kvpress/presses/expected_attention_press.py
@@ -19,22 +19,114 @@ from kvpress.presses.scorer_press import ScorerPress
 @dataclass
 class ExpectedAttentionPress(ScorerPress):
     """
-    Compute scores based on the expected attention on next positions. To do so
-        1. Compute the mean and covariance matrix of the queries before RoPE.
-        2. Compute the RoPE rotation matrix R on next n_future_positions and average it
-        3. Apply R to the mean and covariance matrice of the queries.
-        4. As attention A = exp(Q @ K / sqrt(d)), we compute the expected attention
-        E(A) = exp(K @ mean.T / sqrt(d) + 1/2 K @ cov @ K.T / d)
-        5. Rescale the scores using (scores + epsilon) * ||V||_2
-    The first n_sink tokens are removed from calculations (sink attention phenomenon).
+    Expected attention-based KV cache compression.
+    
+    This method computes importance scores based on the expected attention that
+    future query tokens will pay to current key-value pairs. It uses statistical
+    modeling of query patterns to predict which tokens will be most important
+    for upcoming attention computations.
+    
+    The algorithm works by:
+    1. Computing mean and covariance statistics of queries before RoPE application
+    2. Modeling future query positions using RoPE rotation matrices
+    3. Computing expected attention weights: E[A] = exp(K @ μ^T / √d + ½K @ Σ @ K^T / d)
+    4. Optionally rescaling scores using value norms: (scores + ε) * ||V||₂
+    5. Excluding sink tokens from calculations to handle sink attention phenomenon
+    
+    This approach is particularly effective because:
+    - It predicts future attention patterns rather than relying on past patterns
+    - It accounts for positional encoding effects through RoPE modeling
+    - It can incorporate both mean and variance information from query distributions
+    - It handles the sink attention phenomenon by excluding initial tokens
     """
 
     compression_ratio: float = 0.0
+    """
+    Fraction of key-value pairs to remove during compression.
+    See ScorerPress.compression_ratio for detailed description.
+    """
+    
     n_future_positions: int = 512
+    """
+    Number of future positions to consider when computing expected attention.
+    
+    This parameter controls how far ahead the method looks when predicting
+    future attention patterns. The RoPE rotation matrices are computed for
+    this many future positions and averaged to estimate expected attention.
+    
+    Larger values:
+    - Consider longer-range future dependencies
+    - May provide more stable attention estimates
+    - Require more computation for RoPE matrix calculations
+    
+    Smaller values:
+    - Focus on near-term attention patterns
+    - Are more computationally efficient
+    - May miss longer-range dependencies
+    
+    Default of 512 provides a good balance for most applications.
+    """
+    
     n_sink: int = 4
+    """
+    Number of initial tokens to exclude from compression (sink tokens).
+    
+    The "sink attention" phenomenon refers to the tendency of language models
+    to assign high attention weights to the first few tokens in a sequence,
+    regardless of their semantic importance. These tokens act as "attention sinks."
+    
+    This parameter specifies how many initial tokens to always preserve:
+    - 0: No sink tokens (may hurt performance)
+    - 4: Preserve first 4 tokens (default, works well for most models)
+    - 8+: More conservative, preserves more initial tokens
+    
+    Preserving sink tokens typically improves model performance after compression.
+    """
+    
     use_covariance: bool = True
+    """
+    Whether to include covariance information in expected attention computation.
+    
+    When True, the method computes both mean and covariance of query distributions
+    and uses both in the expected attention formula. When False, only the mean
+    is used, which is computationally cheaper but may be less accurate.
+    
+    - True: Use full statistical model (mean + covariance) - more accurate
+    - False: Use only mean statistics - faster but potentially less precise
+    
+    The covariance term captures the uncertainty in query patterns and generally
+    improves compression quality at the cost of additional computation.
+    """
+    
     use_vnorm: bool = True
+    """
+    Whether to rescale scores using value vector norms.
+    
+    When True, the computed expected attention scores are rescaled by the L2 norm
+    of the corresponding value vectors: (scores + epsilon) * ||V||₂. This helps
+    account for the magnitude of values when determining token importance.
+    
+    - True: Rescale by value norms (generally recommended)
+    - False: Use raw expected attention scores
+    
+    Value norm rescaling typically improves compression quality by considering
+    both attention patterns and the magnitude of information being attended to.
+    """
+    
     epsilon: float = 0.0
+    """
+    Small constant added to scores before value norm rescaling.
+    
+    This parameter is only used when use_vnorm=True. It's added to the expected
+    attention scores before multiplying by value norms to provide numerical
+    stability and prevent issues with very small attention scores.
+    
+    - 0.0: No additional constant (default)
+    - Small positive value: Provides numerical stability
+    
+    Usually the default of 0.0 works well, but small positive values can help
+    in cases where numerical instability is observed.
+    """
 
     def get_query_statistics(self, module: nn.Module, hidden_states: torch.Tensor):
         """

--- a/kvpress/presses/expected_attention_press.py
+++ b/kvpress/presses/expected_attention_press.py
@@ -24,6 +24,13 @@ class ExpectedAttentionPress(ScorerPress):
     Computes importance scores based on expected attention that future queries
     will pay to current key-value pairs. Uses statistical modeling of query
     patterns and RoPE rotation matrices to predict future attention.
+    In particular:
+        1. Compute the mean and covariance matrix of the queries before RoPE.
+        2. Compute the RoPE rotation matrix R on next n_future_positions and average it
+        3. Apply R to the mean and covariance matrice of the queries.
+        4. As attention A = exp(Q @ K / sqrt(d)), we compute the expected attention
+        E(A) = exp(K @ mean.T / sqrt(d) + 1/2 K @ cov @ K.T / d)
+        5. Rescale the scores using (scores + epsilon) * ||V||_2
 
     Parameters
     ----------

--- a/kvpress/presses/finch_press.py
+++ b/kvpress/presses/finch_press.py
@@ -21,9 +21,11 @@ class FinchPress(BasePress):
     SnapKV-style compression with dynamic window sizing based on delimiter tokens.
     Requires input format: `context + delimiter_token + question`. The delimiter
     separates context from query, allowing dynamic window size determination.
-    Based on FINCH (https://direct.mit.edu/tacl/article/doi/10.1162/tacl_a_00716/125280).
 
     Use `update_model_and_tokenizer` method to set delimiter token before use.
+
+
+    Based on FINCH (https://direct.mit.edu/tacl/article/doi/10.1162/tacl_a_00716/125280).
 
     Parameters
     ----------

--- a/kvpress/presses/finch_press.py
+++ b/kvpress/presses/finch_press.py
@@ -17,14 +17,14 @@ from kvpress.presses.snapkv_press import SnapKVPress
 class FinchPress(BasePress):
     """
     FINCH: Prompt-guided Key-Value Cache Compression.
-    
+
     SnapKV-style compression with dynamic window sizing based on delimiter tokens.
     Requires input format: `context + delimiter_token + question`. The delimiter
     separates context from query, allowing dynamic window size determination.
     Based on FINCH (https://direct.mit.edu/tacl/article/doi/10.1162/tacl_a_00716/125280).
-    
+
     Use `update_model_and_tokenizer` method to set delimiter token before use.
-    
+
     Parameters
     ----------
     compression_ratio : float, default=0.0
@@ -140,7 +140,7 @@ class FinchPress(BasePress):
             output = output[:, ~delim_tokens]
         return output
 
-    def update_model_and_tokenizer(self, model, tokenizer, delimiter_token : str = "<|finch_sep|>"):
+    def update_model_and_tokenizer(self, model, tokenizer, delimiter_token: str = "<|finch_sep|>"):
         """
         Set the delimiter token and update the tokenizer accordingly.
         This method should be called before calling the press.
@@ -157,8 +157,10 @@ class FinchPress(BasePress):
     def __call__(self, model):
         # The user should set the delimiter_token_id before calling the press.
         if self.delimiter_token_id is None:
-            raise ValueError("""No delimiter token ID provided.
-                             Use the update_model_and_tokenizer method before calling the press.""")
+            raise ValueError(
+                """No delimiter token ID provided.
+                             Use the update_model_and_tokenizer method before calling the press."""
+            )
 
         with super().__call__(model):
             try:

--- a/kvpress/presses/finch_press.py
+++ b/kvpress/presses/finch_press.py
@@ -24,28 +24,32 @@ class FinchPress(BasePress):
     Based on FINCH (https://direct.mit.edu/tacl/article/doi/10.1162/tacl_a_00716/125280).
     
     Use `update_model_and_tokenizer` method to set delimiter token before use.
+    
+    Parameters
+    ----------
+    compression_ratio : float, default=0.0
+        Fraction of key-value pairs to remove during compression.
+    chunk_length : int, optional
+        Length of chunks for optional chunked compression. None processes entire context at once.
+    normalize_scores : bool, default=True
+        Whether to normalize attention scores by number of non-zero weights.
+    rerotate_keys : bool, default=True
+        Whether to rerotate keys after compression using RoPE for proper positional encoding.
+    delimiter_token : str
+        Delimiter token string separating context from query (set automatically).
+    delimiter_token_id : int
+        Token ID for delimiter token (set automatically).
+    window_size : int
+        Dynamically determined window size based on delimiter position (set automatically).
     """
 
     compression_ratio: float = 0.0
-    """Fraction of key-value pairs to remove during compression."""
-    
     chunk_length: int = None
-    """Length of chunks for optional chunked compression. None processes entire context at once."""
-    
     normalize_scores: bool = True
-    """Whether to normalize attention scores by number of non-zero weights."""
-    
     rerotate_keys: bool = True
-    """Whether to rerotate keys after compression using RoPE for proper positional encoding."""
-    
     delimiter_token: str = field(default=None, init=False)
-    """Delimiter token string separating context from query (set automatically)."""
-    
     delimiter_token_id: int = field(default=None, init=False)
-    """Token ID for delimiter token (set automatically)."""
-    
     window_size: int = field(default=None, init=False)
-    """Dynamically determined window size based on delimiter position (set automatically)."""
 
     def score(self, module, hidden_states, keys, values, attentions, kwargs):
         """

--- a/kvpress/presses/finch_press.py
+++ b/kvpress/presses/finch_press.py
@@ -16,114 +16,36 @@ from kvpress.presses.snapkv_press import SnapKVPress
 @dataclass
 class FinchPress(BasePress):
     """
-    FINCH: Prompt-guided Key-Value Cache Compression for Large Language Models.
+    FINCH: Prompt-guided Key-Value Cache Compression.
     
-    Based on FINCH (https://direct.mit.edu/tacl/article/doi/10.1162/tacl_a_00716/125280),
-    this method implements a SnapKV-style compression with dynamic window sizing based
-    on delimiter tokens. Unlike SnapKV which uses a fixed window size, FINCH adapts
-    the window size based on the structure of the input.
+    SnapKV-style compression with dynamic window sizing based on delimiter tokens.
+    Requires input format: `context + delimiter_token + question`. The delimiter
+    separates context from query, allowing dynamic window size determination.
+    Based on FINCH (https://direct.mit.edu/tacl/article/doi/10.1162/tacl_a_00716/125280).
     
-    The method requires a specific input format:
-    `context + delimiter_token + question`
-    
-    The delimiter token separates the context from the query portion, allowing FINCH
-    to dynamically determine the appropriate window size for attention computation.
-    This makes it particularly suitable for question-answering tasks where the
-    question portion should be used as the attention window.
-    
-    Key features:
-    - Dynamic window sizing based on delimiter tokens
-    - SnapKV-style attention computation within the determined window
-    - Optional score normalization by non-zero attention weights
-    - Optional chunked compression for very long contexts
-    - Optional key rerotation after compression (similar to KeyRerotationPress)
-    
-    The delimiter token must be set using the `update_model_and_tokenizer` method
-    before using this press. This method analyzes the input to find the delimiter
-    and sets the appropriate window size.
-    
-    Note: This implementation does not include chunked prefilling from the original paper.
+    Use `update_model_and_tokenizer` method to set delimiter token before use.
     """
 
     compression_ratio: float = 0.0
-    """
-    Fraction of key-value pairs to remove during compression.
-    See ScorerPress.compression_ratio for detailed description.
-    """
+    """Fraction of key-value pairs to remove during compression."""
     
     chunk_length: int = None
-    """
-    Length of chunks for optional chunked compression.
-    
-    If specified, the context will be processed in chunks of this size rather
-    than as a single block. This can be useful for very long contexts to
-    manage memory usage and computation time.
-    
-    - None: Process the entire context at once (default)
-    - Positive integer: Process in chunks of this size
-    
-    Chunked processing may affect compression quality but can be necessary
-    for very long sequences that exceed memory constraints.
-    """
+    """Length of chunks for optional chunked compression. None processes entire context at once."""
     
     normalize_scores: bool = True
-    """
-    Whether to normalize attention scores by the number of non-zero weights.
-    
-    When True, the computed attention scores are normalized by the count of
-    non-zero attention weights in the window. This normalization can help
-    stabilize the importance scores across different window sizes and
-    attention patterns.
-    
-    - True: Apply normalization (generally recommended)
-    - False: Use raw attention scores
-    
-    Normalization typically improves the stability and quality of compression.
-    """
+    """Whether to normalize attention scores by number of non-zero weights."""
     
     rerotate_keys: bool = True
-    """
-    Whether to rerotate keys after compression using RoPE.
-    
-    When True, the method applies key rerotation after compression to maintain
-    proper positional encoding relationships. This is similar to the functionality
-    provided by KeyRerotationPress and helps preserve attention quality after
-    token removal.
-    
-    - True: Apply key rerotation after compression (recommended)
-    - False: Skip key rerotation (may hurt performance)
-    
-    Key rerotation is generally recommended to maintain proper positional
-    relationships in the compressed sequence.
-    """
+    """Whether to rerotate keys after compression using RoPE for proper positional encoding."""
     
     delimiter_token: str = field(default=None, init=False)
-    """
-    The delimiter token string used to separate context from query.
-    
-    This token is automatically detected and set by the update_model_and_tokenizer
-    method. It should not be set manually during initialization.
-    
-    The delimiter token is used to identify where the context ends and the
-    query begins, allowing FINCH to determine the appropriate window size.
-    """
+    """Delimiter token string separating context from query (set automatically)."""
     
     delimiter_token_id: int = field(default=None, init=False)
-    """
-    The token ID corresponding to the delimiter token.
-    
-    This is automatically set by the update_model_and_tokenizer method based
-    on the tokenizer's vocabulary. It should not be set manually.
-    """
+    """Token ID for delimiter token (set automatically)."""
     
     window_size: int = field(default=None, init=False)
-    """
-    The dynamically determined window size based on delimiter token position.
-    
-    This value is computed during processing based on the position of the
-    delimiter token in the input sequence. It represents the number of tokens
-    in the query portion that will be used for attention computation.
-    """
+    """Dynamically determined window size based on delimiter position (set automatically)."""
 
     def score(self, module, hidden_states, keys, values, attentions, kwargs):
         """

--- a/kvpress/presses/key_rerotation_press.py
+++ b/kvpress/presses/key_rerotation_press.py
@@ -20,9 +20,9 @@ class KeyRerotationPress(BasePress):
     Enhances any ScorerPress by applying key rerotation after compression to maintain
     proper RoPE (Rotary Position Embedding) representations. When tokens are pruned,
     remaining tokens need positional encodings adjusted for their new positions.
-
-    Essential for compression methods that need accurate positional information.
-    Ensures attention computations remain accurate after compression.
+    This method is used in several key-value cache compression methods, such as
+    - SinkCache implementation in Hugging Face's transformers library
+    - FINCH: Prompt-guided Key-Value Cache Compression for Large Language Models
 
     Parameters
     ----------

--- a/kvpress/presses/key_rerotation_press.py
+++ b/kvpress/presses/key_rerotation_press.py
@@ -16,14 +16,14 @@ from kvpress.presses.scorer_press import ScorerPress
 class KeyRerotationPress(BasePress):
     """
     Key Rerotation: RoPE-aware compression wrapper for maintaining positional encoding.
-    
+
     Enhances any ScorerPress by applying key rerotation after compression to maintain
     proper RoPE (Rotary Position Embedding) representations. When tokens are pruned,
     remaining tokens need positional encodings adjusted for their new positions.
-    
+
     Essential for compression methods that need accurate positional information.
     Ensures attention computations remain accurate after compression.
-    
+
     Parameters
     ----------
     press : ScorerPress

--- a/kvpress/presses/key_rerotation_press.py
+++ b/kvpress/presses/key_rerotation_press.py
@@ -17,48 +17,21 @@ class KeyRerotationPress(BasePress):
     """
     Key Rerotation: RoPE-aware compression wrapper for maintaining positional encoding.
     
-    This wrapper enhances any ScorerPress by applying key rerotation after compression
-    to maintain proper RoPE (Rotary Position Embedding) representations. When tokens
-    are pruned from the sequence, the remaining tokens need their positional encodings
-    adjusted to reflect their new positions in the compressed sequence.
+    Enhances any ScorerPress by applying key rerotation after compression to maintain
+    proper RoPE (Rotary Position Embedding) representations. When tokens are pruned,
+    remaining tokens need positional encodings adjusted for their new positions.
     
-    The rerotation process works by:
-    1. Applying the underlying ScorerPress to identify tokens to keep
-    2. Inverse-rotating the selected keys to remove their original RoPE encoding
-    3. Re-applying RoPE with the new consecutive positions after compression
-    4. Ensuring proper positional relationships in the compressed sequence
+    Essential for compression methods that need accurate positional information.
+    Ensures attention computations remain accurate after compression.
     
-    This method is essential for compression techniques that need to maintain
-    accurate positional information, and is used in several key-value cache
-    compression methods including:
-    - SinkCache implementation in Hugging Face's transformers library
-    - FINCH: Prompt-guided Key-Value Cache Compression for Large Language Models
-    - StreamingLLM with proper positional encoding
-    
-    The rerotation ensures that attention computations remain accurate after
-    compression by preserving the relative positional relationships between
-    the remaining tokens.
-    
-    Key benefits:
-    - Maintains accurate positional encoding after token removal
-    - Preserves attention quality in compressed sequences
-    - Can be applied to any underlying ScorerPress method
-    - Essential for models that rely heavily on positional information
+    Parameters
+    ----------
+    press : ScorerPress
+        The underlying scoring method to enhance with key rerotation.
+        Rerotation is applied after the press determines which tokens to keep.
     """
 
     press: ScorerPress
-    """
-    The underlying scoring method to enhance with key rerotation.
-    
-    This should be any ScorerPress subclass that identifies which tokens to
-    keep during compression. The KeyRerotationPress wrapper will apply the
-    scoring method and then rerotate the keys of the selected tokens to
-    maintain proper RoPE positional encoding.
-    
-    The rerotation is applied after the underlying press determines which
-    tokens to keep, ensuring that the compressed sequence maintains accurate
-    positional relationships for attention computation.
-    """
 
     def __post_init__(self):
         assert isinstance(self.press, ScorerPress)

--- a/kvpress/presses/keydiff_press.py
+++ b/kvpress/presses/keydiff_press.py
@@ -15,29 +15,10 @@ class KeyDiffPress(ScorerPress):
     """
     KeyDiff: Key similarity-based KV cache compression.
     
-    Based on KeyDiff (https://arxiv.org/abs/2504.15364), this method evicts tokens
-    based solely on key vector similarity. The approach identifies tokens whose
-    key representations are most similar to the average key pattern and removes
-    them, keeping tokens with more distinctive key vectors.
-    
-    The method works by:
-    1. Computing the average (anchor) key vector across all positions
-    2. Normalizing both individual keys and the anchor using L2 normalization
-    3. Computing cosine similarity between each key and the anchor
-    4. Assigning negative similarity scores (so similar keys get lower scores)
-    5. Pruning tokens with highest similarity (most redundant keys)
-    
-    This approach is based on the intuition that:
-    - Keys with similar patterns provide redundant information
-    - Distinctive keys are more likely to be important for attention
-    - Key similarity is a good proxy for token redundancy
-    - The method is computationally efficient (no attention computation needed)
-    
-    Key characteristics:
-    - Fast computation (only requires similarity calculation)
-    - No dependency on attention weights or query patterns
-    - Focuses on key diversity rather than attention patterns
-    - Can identify redundant tokens effectively
+    Evicts tokens based on key vector similarity to average key pattern.
+    Identifies tokens with most similar keys to average and removes them,
+    keeping tokens with more distinctive key vectors.
+    Based on KeyDiff (https://arxiv.org/abs/2504.15364).
     """
     def score(
         self,

--- a/kvpress/presses/keydiff_press.py
+++ b/kvpress/presses/keydiff_press.py
@@ -14,12 +14,13 @@ from kvpress.presses.scorer_press import ScorerPress
 class KeyDiffPress(ScorerPress):
     """
     KeyDiff: Key similarity-based KV cache compression.
-    
+
     Evicts tokens based on key vector similarity to average key pattern.
     Identifies tokens with most similar keys to average and removes them,
     keeping tokens with more distinctive key vectors.
     Based on KeyDiff (https://arxiv.org/abs/2504.15364).
     """
+
     def score(
         self,
         module: nn.Module,

--- a/kvpress/presses/keydiff_press.py
+++ b/kvpress/presses/keydiff_press.py
@@ -18,7 +18,13 @@ class KeyDiffPress(ScorerPress):
     Evicts tokens based on key vector similarity to average key pattern.
     Identifies tokens with most similar keys to average and removes them,
     keeping tokens with more distinctive key vectors.
+
     Based on KeyDiff (https://arxiv.org/abs/2504.15364).
+
+    Parameters
+    ----------
+    compression_ratio : float, default=0.0
+        Fraction of key-value pairs to remove during compression.
     """
 
     def score(

--- a/kvpress/presses/keydiff_press.py
+++ b/kvpress/presses/keydiff_press.py
@@ -13,7 +13,31 @@ from kvpress.presses.scorer_press import ScorerPress
 @dataclass
 class KeyDiffPress(ScorerPress):
     """
-    KeyDiff (https://arxiv.org/abs/2504.15364) evict tokens based solely on key similarity.
+    KeyDiff: Key similarity-based KV cache compression.
+    
+    Based on KeyDiff (https://arxiv.org/abs/2504.15364), this method evicts tokens
+    based solely on key vector similarity. The approach identifies tokens whose
+    key representations are most similar to the average key pattern and removes
+    them, keeping tokens with more distinctive key vectors.
+    
+    The method works by:
+    1. Computing the average (anchor) key vector across all positions
+    2. Normalizing both individual keys and the anchor using L2 normalization
+    3. Computing cosine similarity between each key and the anchor
+    4. Assigning negative similarity scores (so similar keys get lower scores)
+    5. Pruning tokens with highest similarity (most redundant keys)
+    
+    This approach is based on the intuition that:
+    - Keys with similar patterns provide redundant information
+    - Distinctive keys are more likely to be important for attention
+    - Key similarity is a good proxy for token redundancy
+    - The method is computationally efficient (no attention computation needed)
+    
+    Key characteristics:
+    - Fast computation (only requires similarity calculation)
+    - No dependency on attention weights or query patterns
+    - Focuses on key diversity rather than attention patterns
+    - Can identify redundant tokens effectively
     """
     def score(
         self,

--- a/kvpress/presses/knorm_press.py
+++ b/kvpress/presses/knorm_press.py
@@ -12,7 +12,28 @@ from kvpress.presses.scorer_press import ScorerPress
 
 @dataclass
 class KnormPress(ScorerPress):
-    """Prune KV pairs with highest L2 norm of keys (https://arxiv.org/pdf/2406.11430)"""
+    """
+    Key norm-based KV cache compression.
+    
+    Based on the observation from https://arxiv.org/pdf/2406.11430, this method
+    prunes key-value pairs based on the L2 norm of their key vectors. The intuition
+    is that keys with higher norms tend to have larger magnitudes in the attention
+    computation and may be more important for maintaining model performance.
+    
+    The method works by:
+    1. Computing the L2 norm of each key vector
+    2. Assigning negative norm values as scores (so higher norms get lower scores)
+    3. Pruning tokens with the highest key norms (lowest scores)
+    
+    This approach is simple, efficient, and doesn't require attention computation,
+    making it suitable for scenarios where computational overhead must be minimized.
+    
+    Key characteristics:
+    - Fast computation (only requires norm calculation)
+    - No dependency on attention weights or complex patterns
+    - Works well as a baseline compression method
+    - Can be combined with other methods in ComposedPress
+    """
 
     def score(
         self,

--- a/kvpress/presses/knorm_press.py
+++ b/kvpress/presses/knorm_press.py
@@ -17,7 +17,13 @@ class KnormPress(ScorerPress):
 
     Prunes key-value pairs based on L2 norm of key vectors.
     Simple, efficient method requiring only norm calculation.
+
     Based on https://arxiv.org/pdf/2406.11430.
+
+    Parameters
+    ----------
+    compression_ratio : float, default=0.0
+        Fraction of key-value pairs to remove during compression.
     """
 
     def score(

--- a/kvpress/presses/knorm_press.py
+++ b/kvpress/presses/knorm_press.py
@@ -15,24 +15,10 @@ class KnormPress(ScorerPress):
     """
     Key norm-based KV cache compression.
     
-    Based on the observation from https://arxiv.org/pdf/2406.11430, this method
-    prunes key-value pairs based on the L2 norm of their key vectors. The intuition
-    is that keys with higher norms tend to have larger magnitudes in the attention
-    computation and may be more important for maintaining model performance.
-    
-    The method works by:
-    1. Computing the L2 norm of each key vector
-    2. Assigning negative norm values as scores (so higher norms get lower scores)
-    3. Pruning tokens with the highest key norms (lowest scores)
-    
-    This approach is simple, efficient, and doesn't require attention computation,
-    making it suitable for scenarios where computational overhead must be minimized.
-    
-    Key characteristics:
-    - Fast computation (only requires norm calculation)
-    - No dependency on attention weights or complex patterns
-    - Works well as a baseline compression method
-    - Can be combined with other methods in ComposedPress
+    Prunes key-value pairs based on L2 norm of key vectors. Keys with higher
+    norms tend to have larger magnitudes in attention computation and may be
+    more important. Simple, efficient method requiring only norm calculation.
+    Based on https://arxiv.org/pdf/2406.11430.
     """
 
     def score(

--- a/kvpress/presses/knorm_press.py
+++ b/kvpress/presses/knorm_press.py
@@ -14,7 +14,7 @@ from kvpress.presses.scorer_press import ScorerPress
 class KnormPress(ScorerPress):
     """
     Key norm-based KV cache compression.
-    
+
     Prunes key-value pairs based on L2 norm of key vectors. Keys with higher
     norms tend to have larger magnitudes in attention computation and may be
     more important. Simple, efficient method requiring only norm calculation.

--- a/kvpress/presses/knorm_press.py
+++ b/kvpress/presses/knorm_press.py
@@ -15,9 +15,8 @@ class KnormPress(ScorerPress):
     """
     Key norm-based KV cache compression.
 
-    Prunes key-value pairs based on L2 norm of key vectors. Keys with higher
-    norms tend to have larger magnitudes in attention computation and may be
-    more important. Simple, efficient method requiring only norm calculation.
+    Prunes key-value pairs based on L2 norm of key vectors.
+    Simple, efficient method requiring only norm calculation.
     Based on https://arxiv.org/pdf/2406.11430.
     """
 

--- a/kvpress/presses/lagkv_press.py
+++ b/kvpress/presses/lagkv_press.py
@@ -15,82 +15,32 @@ class LagKVPress(ScorerPress):
     """
     LagKV: Lag-relative information-based KV cache compression.
     
-    Based on LagKV (https://arxiv.org/abs/2504.04704), this method compresses
-    the KV cache by leveraging lag-relative information between different
-    partitions of the sequence. The approach divides the sequence into
-    partitions and uses subsequent partitions as references for scoring
-    tokens in prior partitions.
-    
-    The method works by:
-    1. Preserving the first n_sink tokens (attention sinks)
-    2. Dividing the remaining sequence into partitions of size lag_size
-    3. Using each partition as a reference to score tokens in the previous partition
-    4. Computing importance scores based on the lag-relative information
-    5. Optionally enabling cross-partition scoring for more flexible allocation
-    
-    This approach is particularly effective because:
-    - It captures temporal dependencies between different parts of the sequence
-    - It provides a structured way to identify important tokens across partitions
-    - It can adapt to different attention patterns within each partition
-    - It maintains computational efficiency through partitioned processing
-    
-    The lag-relative scoring helps identify tokens that are important for
-    maintaining coherence across different temporal segments of the input.
+    Compresses KV cache by leveraging lag-relative information between sequence
+    partitions. Divides sequence into partitions and uses subsequent partitions
+    as references for scoring tokens in prior partitions.
+    Based on LagKV (https://arxiv.org/abs/2504.04704).
     """
 
     compression_ratio: float = 0.0
-    """
-    Fraction of key-value pairs to remove during compression.
-    See ScorerPress.compression_ratio for detailed description.
-    """
+    """Fraction of key-value pairs to remove during compression."""
     
     n_sink: int = 4
-    """
-    Number of initial tokens to preserve as attention sinks.
-    
-    These tokens at the beginning of the sequence are never pruned and serve
-    as attention sinks that help maintain model stability. The sink tokens
-    are excluded from the partitioning and lag-relative scoring process.
-    
-    See StreamingLLMPress.n_sink for detailed description of sink tokens.
-    """
+    """Number of initial tokens to preserve as attention sinks."""
     
     lag_size: int = 128
     """
     Size of each partition for lag-relative scoring.
     
-    The sequence (after sink tokens) is divided into non-overlapping partitions
-    of this size. Each partition serves as a reference for scoring tokens in
-    the previous partition, creating a lag-relative information flow.
-    
-    Larger partition sizes:
-    - Provide more context for lag-relative scoring
-    - May capture longer-range dependencies within partitions
-    - Reduce the number of partitions to process
-    
-    Smaller partition sizes:
-    - Create more fine-grained lag-relative relationships
-    - May be more responsive to local attention patterns
-    - Increase the number of partition boundaries
-    
-    The default of 128 provides a good balance between context and granularity.
+    Sequence is divided into partitions of this size, with each partition
+    serving as reference for scoring tokens in the previous partition.
     """
     
     cross_scoring: bool = False
     """
-    Whether to enable cross-partition scoring (experimental feature).
+    Whether to enable cross-partition scoring (experimental).
     
-    When True, the scoring is not limited to within-partition relationships
-    and can consider cross-partition dependencies. This allows for more
-    flexible token allocation across the entire sequence.
-    
-    - False: Limit scoring to within-partition relationships (default)
-    - True: Enable cross-partition scoring for more flexible allocation
-    
-    Cross-scoring can be particularly useful when combined with wrapper
-    methods like AdaKVPress that need to allocate tokens across attention heads.
-    
-    Note: This is an experimental feature and may affect compression behavior.
+    When True, scoring considers cross-partition dependencies rather than
+    limiting to within-partition relationships. Useful with AdaKVPress.
     """
 
     def score(

--- a/kvpress/presses/lagkv_press.py
+++ b/kvpress/presses/lagkv_press.py
@@ -19,29 +19,27 @@ class LagKVPress(ScorerPress):
     partitions. Divides sequence into partitions and uses subsequent partitions
     as references for scoring tokens in prior partitions.
     Based on LagKV (https://arxiv.org/abs/2504.04704).
+    
+    Parameters
+    ----------
+    compression_ratio : float, default=0.0
+        Fraction of key-value pairs to remove during compression.
+    n_sink : int, default=4
+        Number of initial tokens to preserve as attention sinks.
+    lag_size : int, default=128
+        Size of each partition for lag-relative scoring.
+        Sequence is divided into partitions of this size, with each partition
+        serving as reference for scoring tokens in the previous partition.
+    cross_scoring : bool, default=False
+        Whether to enable cross-partition scoring (experimental).
+        When True, scoring considers cross-partition dependencies rather than
+        limiting to within-partition relationships. Useful with AdaKVPress.
     """
 
     compression_ratio: float = 0.0
-    """Fraction of key-value pairs to remove during compression."""
-    
     n_sink: int = 4
-    """Number of initial tokens to preserve as attention sinks."""
-    
     lag_size: int = 128
-    """
-    Size of each partition for lag-relative scoring.
-    
-    Sequence is divided into partitions of this size, with each partition
-    serving as reference for scoring tokens in the previous partition.
-    """
-    
     cross_scoring: bool = False
-    """
-    Whether to enable cross-partition scoring (experimental).
-    
-    When True, scoring considers cross-partition dependencies rather than
-    limiting to within-partition relationships. Useful with AdaKVPress.
-    """
 
     def score(
         self,

--- a/kvpress/presses/lagkv_press.py
+++ b/kvpress/presses/lagkv_press.py
@@ -13,21 +13,85 @@ from kvpress.presses.scorer_press import ScorerPress
 @dataclass
 class LagKVPress(ScorerPress):
     """
-    Prune KV pairs with lag-relative information (https://arxiv.org/abs/2504.04704)
-
-    Args:
-        n_sink (`int`):
-            The number of sink tokens.
-        lag_size (`int`):
-            The size of the partition. The subsequent partition will serve as a reference for the prior one.
-        cross_scoring (`bool`):
-            (experimental) if cross scoring is enabled, the score will not be limited to inside partion.
-            Since the score is totally normalized, it's possible use it to allocating KV among heads.
-            This switch will be useful for Press Wrapper like AdaKVPress.
+    LagKV: Lag-relative information-based KV cache compression.
+    
+    Based on LagKV (https://arxiv.org/abs/2504.04704), this method compresses
+    the KV cache by leveraging lag-relative information between different
+    partitions of the sequence. The approach divides the sequence into
+    partitions and uses subsequent partitions as references for scoring
+    tokens in prior partitions.
+    
+    The method works by:
+    1. Preserving the first n_sink tokens (attention sinks)
+    2. Dividing the remaining sequence into partitions of size lag_size
+    3. Using each partition as a reference to score tokens in the previous partition
+    4. Computing importance scores based on the lag-relative information
+    5. Optionally enabling cross-partition scoring for more flexible allocation
+    
+    This approach is particularly effective because:
+    - It captures temporal dependencies between different parts of the sequence
+    - It provides a structured way to identify important tokens across partitions
+    - It can adapt to different attention patterns within each partition
+    - It maintains computational efficiency through partitioned processing
+    
+    The lag-relative scoring helps identify tokens that are important for
+    maintaining coherence across different temporal segments of the input.
     """
+
+    compression_ratio: float = 0.0
+    """
+    Fraction of key-value pairs to remove during compression.
+    See ScorerPress.compression_ratio for detailed description.
+    """
+    
     n_sink: int = 4
+    """
+    Number of initial tokens to preserve as attention sinks.
+    
+    These tokens at the beginning of the sequence are never pruned and serve
+    as attention sinks that help maintain model stability. The sink tokens
+    are excluded from the partitioning and lag-relative scoring process.
+    
+    See StreamingLLMPress.n_sink for detailed description of sink tokens.
+    """
+    
     lag_size: int = 128
+    """
+    Size of each partition for lag-relative scoring.
+    
+    The sequence (after sink tokens) is divided into non-overlapping partitions
+    of this size. Each partition serves as a reference for scoring tokens in
+    the previous partition, creating a lag-relative information flow.
+    
+    Larger partition sizes:
+    - Provide more context for lag-relative scoring
+    - May capture longer-range dependencies within partitions
+    - Reduce the number of partitions to process
+    
+    Smaller partition sizes:
+    - Create more fine-grained lag-relative relationships
+    - May be more responsive to local attention patterns
+    - Increase the number of partition boundaries
+    
+    The default of 128 provides a good balance between context and granularity.
+    """
+    
     cross_scoring: bool = False
+    """
+    Whether to enable cross-partition scoring (experimental feature).
+    
+    When True, the scoring is not limited to within-partition relationships
+    and can consider cross-partition dependencies. This allows for more
+    flexible token allocation across the entire sequence.
+    
+    - False: Limit scoring to within-partition relationships (default)
+    - True: Enable cross-partition scoring for more flexible allocation
+    
+    Cross-scoring can be particularly useful when combined with wrapper
+    methods like AdaKVPress that need to allocate tokens across attention heads.
+    
+    Note: This is an experimental feature and may affect compression behavior.
+    """
 
     def score(
         self,

--- a/kvpress/presses/lagkv_press.py
+++ b/kvpress/presses/lagkv_press.py
@@ -18,6 +18,7 @@ class LagKVPress(ScorerPress):
     Compresses KV cache by leveraging lag-relative information between sequence
     partitions. Divides sequence into partitions and uses subsequent partitions
     as references for scoring tokens in prior partitions.
+
     Based on LagKV (https://arxiv.org/abs/2504.04704).
 
     Parameters

--- a/kvpress/presses/observed_attention_press.py
+++ b/kvpress/presses/observed_attention_press.py
@@ -20,9 +20,11 @@ class ObservedAttentionPress(ScorerPress):
 
     Computes importance scores based on actual attention weights observed during
     forward pass. Score for each key-value pair is the average attention weight
-    it receives from all query tokens. Related to H2O (https://arxiv.org/abs/2306.14048).
+    it receives from all query tokens.
 
     Requires: output_attentions=True and attn_implementation="eager".
+
+    Related to H2O (https://arxiv.org/abs/2306.14048).
 
     Parameters
     ----------

--- a/kvpress/presses/observed_attention_press.py
+++ b/kvpress/presses/observed_attention_press.py
@@ -18,44 +18,23 @@ class ObservedAttentionPress(ScorerPress):
     """
     Observed attention-based KV cache compression.
     
-    This method computes importance scores based on the actual attention weights
-    observed during the forward pass. The score for each key-value pair is defined
-    as the average attention weight it receives from all query tokens in the sequence.
+    Computes importance scores based on actual attention weights observed during
+    forward pass. Score for each key-value pair is the average attention weight
+    it receives from all query tokens. Related to H2O (https://arxiv.org/abs/2306.14048).
     
-    This approach is related to H2O (https://arxiv.org/abs/2306.14048) and provides
-    a direct measure of how much attention each token actually receives during processing.
-    
-    Requirements:
-    - Model must be configured with output_attentions=True
-    - Model must use attn_implementation="eager" (not flash attention)
-    - Attention weights must be available in the forward pass output
-    
-    The method works by:
-    1. Extracting attention weights from the model's forward pass
-    2. Computing average attention received by each key position
-    3. Using these averages as importance scores for compression
+    Requires: output_attentions=True and attn_implementation="eager".
     """
 
     compression_ratio: float = 0.0
-    """
-    Fraction of key-value pairs to remove during compression.
-    See ScorerPress.compression_ratio for detailed description.
-    """
+    """Fraction of key-value pairs to remove during compression."""
     
     output_attentions: bool = False
     """
-    Whether to return attention weights in the model output.
+    Whether to return attention weights in model output.
     
-    This parameter controls whether attention weights are included in the
-    model's output after compression is applied. The attention weights are
-    always needed internally for computing importance scores, but they can
-    be removed from the output to save memory.
-    
-    - True: Include attention weights in model output (uses more memory)
-    - False: Remove attention weights from output after scoring (saves memory)
-    
-    Note: Regardless of this setting, attention weights must be computed
-    during the forward pass (requires output_attentions=True in model config).
+    Controls whether attention weights are included in output after compression.
+    Attention weights are always needed internally for scoring but can be removed
+    from output to save memory.
     """
 
     def __post_init__(self):

--- a/kvpress/presses/observed_attention_press.py
+++ b/kvpress/presses/observed_attention_press.py
@@ -23,19 +23,20 @@ class ObservedAttentionPress(ScorerPress):
     it receives from all query tokens. Related to H2O (https://arxiv.org/abs/2306.14048).
 
     Requires: output_attentions=True and attn_implementation="eager".
+
+    Parameters
+    ----------
+    compression_ratio : float, default=0.0
+        Fraction of key-value pairs to remove during compression.
+    output_attentions : bool, default=False
+        Whether to return attention weights in model output.
+        Controls whether attention weights are included in output after compression.
+        Attention weights are always needed internally for scoring but can be removed
+        from output to save memory.
     """
 
     compression_ratio: float = 0.0
-    """Fraction of key-value pairs to remove during compression."""
-
     output_attentions: bool = False
-    """
-    Whether to return attention weights in model output.
-    
-    Controls whether attention weights are included in output after compression.
-    Attention weights are always needed internally for scoring but can be removed
-    from output to save memory.
-    """
 
     def __post_init__(self):
         if not self.output_attentions:

--- a/kvpress/presses/observed_attention_press.py
+++ b/kvpress/presses/observed_attention_press.py
@@ -17,17 +17,17 @@ logger = logging.getLogger(__name__)
 class ObservedAttentionPress(ScorerPress):
     """
     Observed attention-based KV cache compression.
-    
+
     Computes importance scores based on actual attention weights observed during
     forward pass. Score for each key-value pair is the average attention weight
     it receives from all query tokens. Related to H2O (https://arxiv.org/abs/2306.14048).
-    
+
     Requires: output_attentions=True and attn_implementation="eager".
     """
 
     compression_ratio: float = 0.0
     """Fraction of key-value pairs to remove during compression."""
-    
+
     output_attentions: bool = False
     """
     Whether to return attention weights in model output.

--- a/kvpress/presses/observed_attention_press.py
+++ b/kvpress/presses/observed_attention_press.py
@@ -16,13 +16,47 @@ logger = logging.getLogger(__name__)
 @dataclass
 class ObservedAttentionPress(ScorerPress):
     """
-    The observed attention score is defined as the average attention weight over all prompt tokens
-    Requires output_attentions=True and attn_implementation="eager" to have access to attentions
-    This approach is related to H2O (https://arxiv.org/abs/2306.14048).
+    Observed attention-based KV cache compression.
+    
+    This method computes importance scores based on the actual attention weights
+    observed during the forward pass. The score for each key-value pair is defined
+    as the average attention weight it receives from all query tokens in the sequence.
+    
+    This approach is related to H2O (https://arxiv.org/abs/2306.14048) and provides
+    a direct measure of how much attention each token actually receives during processing.
+    
+    Requirements:
+    - Model must be configured with output_attentions=True
+    - Model must use attn_implementation="eager" (not flash attention)
+    - Attention weights must be available in the forward pass output
+    
+    The method works by:
+    1. Extracting attention weights from the model's forward pass
+    2. Computing average attention received by each key position
+    3. Using these averages as importance scores for compression
     """
 
     compression_ratio: float = 0.0
+    """
+    Fraction of key-value pairs to remove during compression.
+    See ScorerPress.compression_ratio for detailed description.
+    """
+    
     output_attentions: bool = False
+    """
+    Whether to return attention weights in the model output.
+    
+    This parameter controls whether attention weights are included in the
+    model's output after compression is applied. The attention weights are
+    always needed internally for computing importance scores, but they can
+    be removed from the output to save memory.
+    
+    - True: Include attention weights in model output (uses more memory)
+    - False: Remove attention weights from output after scoring (saves memory)
+    
+    Note: Regardless of this setting, attention weights must be computed
+    during the forward pass (requires output_attentions=True in model config).
+    """
 
     def __post_init__(self):
         if not self.output_attentions:

--- a/kvpress/presses/per_layer_compression_press.py
+++ b/kvpress/presses/per_layer_compression_press.py
@@ -18,8 +18,61 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class PerLayerCompressionPress(BasePress):
+    """
+    Per-layer compression: Apply different compression ratios to different layers.
+    
+    This wrapper allows applying layer-specific compression ratios using any
+    underlying ScorerPress method. Different layers in transformer models may
+    have different importance and attention patterns, so layer-specific compression
+    can potentially improve the quality-efficiency trade-off.
+    
+    The method works by:
+    1. Taking a base ScorerPress method and a list of compression ratios
+    2. Dynamically setting the compression ratio based on the current layer
+    3. Applying the underlying scoring method with the layer-specific ratio
+    4. Restoring the original compression ratio after processing
+    
+    Example usage:
+    ```python
+    # Apply different compression to different layers
+    press = PerLayerCompressionPress(
+        press=SnapKVPress(),
+        compression_ratios=[0.1, 0.2, 0.3, 0.4]  # Increasing compression by layer
+    )
+    ```
+    
+    **Important**: This is an experimental feature that only works with flash attention.
+    Make sure your model is configured to use flash attention before using this wrapper.
+    
+    The average compression ratio across all layers is reported as the overall
+    compression ratio for this press.
+    """
+
     press: ScorerPress
+    """
+    The underlying scoring method to apply with layer-specific compression ratios.
+    
+    This should be any ScorerPress subclass that supports dynamic compression_ratio
+    setting. The wrapper will temporarily modify the compression_ratio of this
+    press for each layer.
+    """
+    
     compression_ratios: List[float]
+    """
+    List of compression ratios to apply to each layer.
+    
+    The length of this list should match the number of layers in the model.
+    Each value should be between 0.0 and 1.0, representing the fraction of
+    tokens to remove for that specific layer.
+    
+    Example patterns:
+    - [0.1, 0.2, 0.3, 0.4]: Increasing compression in later layers
+    - [0.3, 0.1, 0.1, 0.3]: Higher compression in first and last layers
+    - [0.2] * 32: Uniform compression across all layers (equivalent to single ratio)
+    
+    The ratios allow fine-tuning compression based on layer-specific importance
+    or attention patterns observed in the model.
+    """
 
     def __post_init__(self):
         logger.warning(

--- a/kvpress/presses/per_layer_compression_press.py
+++ b/kvpress/presses/per_layer_compression_press.py
@@ -21,58 +21,24 @@ class PerLayerCompressionPress(BasePress):
     """
     Per-layer compression: Apply different compression ratios to different layers.
     
-    This wrapper allows applying layer-specific compression ratios using any
-    underlying ScorerPress method. Different layers in transformer models may
-    have different importance and attention patterns, so layer-specific compression
-    can potentially improve the quality-efficiency trade-off.
+    Wrapper that applies layer-specific compression ratios using any underlying
+    ScorerPress method. Different layers may have different importance patterns,
+    so layer-specific compression can improve quality-efficiency trade-offs.
     
-    The method works by:
-    1. Taking a base ScorerPress method and a list of compression ratios
-    2. Dynamically setting the compression ratio based on the current layer
-    3. Applying the underlying scoring method with the layer-specific ratio
-    4. Restoring the original compression ratio after processing
+    **Important**: Experimental feature that only works with flash attention.
     
-    Example usage:
-    ```python
-    # Apply different compression to different layers
-    press = PerLayerCompressionPress(
-        press=SnapKVPress(),
-        compression_ratios=[0.1, 0.2, 0.3, 0.4]  # Increasing compression by layer
-    )
-    ```
-    
-    **Important**: This is an experimental feature that only works with flash attention.
-    Make sure your model is configured to use flash attention before using this wrapper.
-    
-    The average compression ratio across all layers is reported as the overall
-    compression ratio for this press.
+    Parameters
+    ----------
+    press : ScorerPress
+        The underlying scoring method to apply with layer-specific compression ratios.
+    compression_ratios : List[float]
+        List of compression ratios to apply to each layer.
+        Length should match number of model layers. Each value between 0.0-1.0
+        represents fraction of tokens to remove for that layer.
     """
 
     press: ScorerPress
-    """
-    The underlying scoring method to apply with layer-specific compression ratios.
-    
-    This should be any ScorerPress subclass that supports dynamic compression_ratio
-    setting. The wrapper will temporarily modify the compression_ratio of this
-    press for each layer.
-    """
-    
     compression_ratios: List[float]
-    """
-    List of compression ratios to apply to each layer.
-    
-    The length of this list should match the number of layers in the model.
-    Each value should be between 0.0 and 1.0, representing the fraction of
-    tokens to remove for that specific layer.
-    
-    Example patterns:
-    - [0.1, 0.2, 0.3, 0.4]: Increasing compression in later layers
-    - [0.3, 0.1, 0.1, 0.3]: Higher compression in first and last layers
-    - [0.2] * 32: Uniform compression across all layers (equivalent to single ratio)
-    
-    The ratios allow fine-tuning compression based on layer-specific importance
-    or attention patterns observed in the model.
-    """
 
     def __post_init__(self):
         logger.warning(

--- a/kvpress/presses/per_layer_compression_press.py
+++ b/kvpress/presses/per_layer_compression_press.py
@@ -20,13 +20,13 @@ logger = logging.getLogger(__name__)
 class PerLayerCompressionPress(BasePress):
     """
     Per-layer compression: Apply different compression ratios to different layers.
-    
+
     Wrapper that applies layer-specific compression ratios using any underlying
     ScorerPress method. Different layers may have different importance patterns,
     so layer-specific compression can improve quality-efficiency trade-offs.
-    
+
     **Important**: Experimental feature that only works with flash attention.
-    
+
     Parameters
     ----------
     press : ScorerPress

--- a/kvpress/presses/pyramidkv_press.py
+++ b/kvpress/presses/pyramidkv_press.py
@@ -22,24 +22,25 @@ class PyramidKVPress(SnapKVPress):
     more tokens to lower layers and fewer to higher layers. Based on the
     observation that lower layers need more context while higher layers
     can work with less. Based on PyramidKV (https://arxiv.org/abs/2406.02069).
+
+    Parameters
+    ----------
+    compression_ratio : float, default=0.0
+        Fraction of key-value pairs to remove during compression.
+    window_size : int, default=64
+        Base window size for attention computation, used in pyramid budget calculation.
+    kernel_size : int, default=5
+        Size of the pooling kernel for attention smoothing (inherited from SnapKV).
+    beta : int, default=20
+        Hyperparameter controlling the pyramid's shape and steepness.
+        Larger values create steeper pyramids with more dramatic differences between
+        layers. Smaller values create gentler, more balanced allocation across layers.
     """
 
     compression_ratio: float = 0.0
-    """Fraction of key-value pairs to remove during compression."""
-
     window_size: int = 64
-    """Base window size for attention computation, used in pyramid budget calculation."""
-
     kernel_size: int = 5
-    """Size of the pooling kernel for attention smoothing (inherited from SnapKV)."""
-
     beta: int = 20
-    """
-    Hyperparameter controlling the pyramid's shape and steepness.
-    
-    Larger values create steeper pyramids with more dramatic differences between
-    layers. Smaller values create gentler, more balanced allocation across layers.
-    """
 
     def get_layer_budget(
         self,
@@ -48,6 +49,18 @@ class PyramidKVPress(SnapKVPress):
     ) -> int:
         """
         Compute the budget for each layer based on the pyramid shape.
+        We use the budget calculation formula from:
+        https://github.com/Zefan-Cai/KVCache-Factory/blob/main/pyramidkv/pyramidkv_utils.py#L197
+
+        This implementation always applies compression_ratio,
+        instead of disabling compression or keeping fixed budget for short queries like the original code.
+
+        max_capacity_prompt is calculated as:
+        max_num + min_num   &= (max_capacity_prompt - window_size) * 2
+        total_kvcache_size  &= \frac{(max_num + min_num) * num_layers}{2}
+                            &= (max_capacity_prompt - window_size) * num_layers
+        total_kvcache_size  &= query_length * num_layers * (1 - compression_ratio)
+        max_capacity_prompt &= window_size + query_length * (1 - compression_ratio)
         """
         assert self.beta >= 1, "Beta should >= 1"
 

--- a/kvpress/presses/pyramidkv_press.py
+++ b/kvpress/presses/pyramidkv_press.py
@@ -18,89 +18,27 @@ class PyramidKVPress(SnapKVPress):
     """
     PyramidKV: Layer-wise adaptive KV cache allocation with pyramid structure.
     
-    Based on PyramidKV (https://arxiv.org/abs/2406.02069), this method dynamically
-    adjusts KV cache sizes across different transformer layers, following a pyramid
-    structure where lower layers retain more tokens and higher layers retain fewer.
-    
-    The pyramid allocation is based on the observation that:
-    - Lower layers capture more basic linguistic patterns and need more context
-    - Higher layers focus on more abstract representations and can work with less context
-    - A gradual reduction from bottom to top layers optimizes the memory-performance trade-off
-    
-    The method works by:
-    1. Computing a layer-specific budget using the pyramid formula
-    2. Allocating more cache capacity to lower layers (larger budgets)
-    3. Allocating less cache capacity to higher layers (smaller budgets)
-    4. Using SnapKV-style attention computation within each layer's budget
-    5. Applying the beta parameter to control the pyramid's steepness
-    
-    Budget calculation follows the formula:
-    ```
-    max_capacity_prompt = window_size + query_length * (1 - compression_ratio)
-    ```
-    
-    Key advantages:
-    - Optimizes memory usage across the entire model depth
-    - Maintains performance by preserving more context where it's most needed
-    - Provides fine-grained control over layer-wise compression
-    - Builds upon the proven SnapKV attention mechanism
-    
-    Note: This implementation always applies the specified compression_ratio,
-    unlike the original code which may disable compression for short queries.
+    Dynamically adjusts KV cache sizes across transformer layers, allocating
+    more tokens to lower layers and fewer to higher layers. Based on the
+    observation that lower layers need more context while higher layers
+    can work with less. Based on PyramidKV (https://arxiv.org/abs/2406.02069).
     """
 
     compression_ratio: float = 0.0
-    """
-    Fraction of key-value pairs to remove during compression.
-    
-    This parameter controls the overall compression level across all layers.
-    The actual compression per layer varies according to the pyramid structure,
-    but the total compression across all layers averages to this ratio.
-    
-    See ScorerPress.compression_ratio for detailed description.
-    """
+    """Fraction of key-value pairs to remove during compression."""
     
     window_size: int = 64
-    """
-    Base window size for attention computation.
-    
-    This parameter works similarly to SnapKVPress.window_size but is used
-    in the pyramid budget calculation. Each layer's effective window size
-    may vary based on the pyramid allocation.
-    
-    See SnapKVPress.window_size for detailed description.
-    """
+    """Base window size for attention computation, used in pyramid budget calculation."""
     
     kernel_size: int = 5
-    """
-    Size of the pooling kernel for attention smoothing.
-    
-    This parameter is inherited from SnapKVPress and controls the pooling
-    operation applied to attention weights for more stable importance scores.
-    
-    See SnapKVPress.kernel_size for detailed description.
-    """
+    """Size of the pooling kernel for attention smoothing (inherited from SnapKV)."""
     
     beta: int = 20
     """
     Hyperparameter controlling the pyramid's shape and steepness.
     
-    This parameter adjusts how aggressively the cache allocation decreases
-    from lower to higher layers. It controls the "steepness" of the pyramid:
-    
-    Larger beta values:
-    - Create a steeper pyramid (more dramatic difference between layers)
-    - Allocate much more cache to lower layers, much less to higher layers
-    - May provide better compression but could hurt higher-layer performance
-    
-    Smaller beta values:
-    - Create a gentler pyramid (more gradual difference between layers)
-    - Provide more balanced allocation across layers
-    - May be safer but less aggressive in compression
-    
-    The default value of 20 provides a good balance for most models and tasks.
-    Fine-tuning this parameter can help optimize the trade-off between
-    memory usage and model performance for specific use cases.
+    Larger values create steeper pyramids with more dramatic differences between
+    layers. Smaller values create gentler, more balanced allocation across layers.
     """
 
     def get_layer_budget(

--- a/kvpress/presses/pyramidkv_press.py
+++ b/kvpress/presses/pyramidkv_press.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 class PyramidKVPress(SnapKVPress):
     """
     PyramidKV: Layer-wise adaptive KV cache allocation with pyramid structure.
-    
+
     Dynamically adjusts KV cache sizes across transformer layers, allocating
     more tokens to lower layers and fewer to higher layers. Based on the
     observation that lower layers need more context while higher layers
@@ -26,13 +26,13 @@ class PyramidKVPress(SnapKVPress):
 
     compression_ratio: float = 0.0
     """Fraction of key-value pairs to remove during compression."""
-    
+
     window_size: int = 64
     """Base window size for attention computation, used in pyramid budget calculation."""
-    
+
     kernel_size: int = 5
     """Size of the pooling kernel for attention smoothing (inherited from SnapKV)."""
-    
+
     beta: int = 20
     """
     Hyperparameter controlling the pyramid's shape and steepness.

--- a/kvpress/presses/pyramidkv_press.py
+++ b/kvpress/presses/pyramidkv_press.py
@@ -21,7 +21,9 @@ class PyramidKVPress(SnapKVPress):
     Dynamically adjusts KV cache sizes across transformer layers, allocating
     more tokens to lower layers and fewer to higher layers. Based on the
     observation that lower layers need more context while higher layers
-    can work with less. Based on PyramidKV (https://arxiv.org/abs/2406.02069).
+    can work with less.
+
+    Based on PyramidKV (https://arxiv.org/abs/2406.02069).
 
     Parameters
     ----------

--- a/kvpress/presses/qfilter_press.py
+++ b/kvpress/presses/qfilter_press.py
@@ -20,7 +20,27 @@ class QFilters(torch.nn.Module, PyTorchModelHubMixin):
 @dataclass
 class QFilterPress(ScorerPress):
     """
-    Prune KV pairs with Q-filters
+    Q-Filter: Learned filter-based KV cache compression.
+    
+    This method uses pre-trained learned filters (Q-filters) to score and compress
+    key-value pairs. Unlike heuristic-based methods, Q-filters are neural network
+    parameters that have been trained to identify important tokens for specific
+    model architectures.
+    
+    The method works by:
+    1. Loading pre-trained Q-filter parameters for the specific model
+    2. Computing dot products between keys and the learned filters
+    3. Using these dot products as importance scores for compression
+    4. Pruning tokens with the lowest filter response scores
+    
+    Key characteristics:
+    - Uses learned parameters rather than heuristics
+    - Model-specific filters optimized for each architecture
+    - Potentially more accurate than generic scoring methods
+    - Requires pre-trained filter parameters to be available
+    
+    The Q-filters are automatically loaded based on the model name and are
+    expected to be available in a Hugging Face model collection.
     """
 
     def __post_init_from_model__(self, model):

--- a/kvpress/presses/qfilter_press.py
+++ b/kvpress/presses/qfilter_press.py
@@ -41,6 +41,13 @@ class QFilterPress(ScorerPress):
 
     The Q-filters are automatically loaded based on the model name and are
     expected to be available in a Hugging Face model collection.
+
+    Based on Q-Filter (https://arxiv.org/abs/2503.02812).
+
+    Parameters
+    ----------
+    compression_ratio : float, default=0.0
+        Fraction of key-value pairs to remove during compression.
     """
 
     def __post_init_from_model__(self, model):

--- a/kvpress/presses/qfilter_press.py
+++ b/kvpress/presses/qfilter_press.py
@@ -23,9 +23,8 @@ class QFilterPress(ScorerPress):
     Q-Filter: Learned filter-based KV cache compression.
 
     This method uses pre-trained learned filters (Q-filters) to score and compress
-    key-value pairs. Unlike heuristic-based methods, Q-filters are neural network
-    parameters that have been trained to identify important tokens for specific
-    model architectures.
+    key-value pairs. Unlike heuristic-based methods,
+    Q-filters are vectors that identify important tokens for specific model architectures.
 
     The method works by:
     1. Loading pre-trained Q-filter parameters for the specific model

--- a/kvpress/presses/qfilter_press.py
+++ b/kvpress/presses/qfilter_press.py
@@ -1,9 +1,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from functools import cache
 from contextlib import contextmanager
 from dataclasses import dataclass
+from functools import cache
 
 import torch
 from huggingface_hub import PyTorchModelHubMixin, get_collection
@@ -21,24 +21,24 @@ class QFilters(torch.nn.Module, PyTorchModelHubMixin):
 class QFilterPress(ScorerPress):
     """
     Q-Filter: Learned filter-based KV cache compression.
-    
+
     This method uses pre-trained learned filters (Q-filters) to score and compress
     key-value pairs. Unlike heuristic-based methods, Q-filters are neural network
     parameters that have been trained to identify important tokens for specific
     model architectures.
-    
+
     The method works by:
     1. Loading pre-trained Q-filter parameters for the specific model
     2. Computing dot products between keys and the learned filters
     3. Using these dot products as importance scores for compression
     4. Pruning tokens with the lowest filter response scores
-    
+
     Key characteristics:
     - Uses learned parameters rather than heuristics
     - Model-specific filters optimized for each architecture
     - Potentially more accurate than generic scoring methods
     - Requires pre-trained filter parameters to be available
-    
+
     The Q-filters are automatically loaded based on the model name and are
     expected to be available in a Hugging Face model collection.
     """

--- a/kvpress/presses/random_press.py
+++ b/kvpress/presses/random_press.py
@@ -16,8 +16,7 @@ class RandomPress(ScorerPress):
     """
     Random KV cache compression for baseline comparison.
 
-    Randomly selects which key-value pairs to prune, without considering
-    importance or attention patterns. Useful for establishing baseline
+    Randomly selects which key-value pairs to prune. Useful for establishing baseline
     performance metrics and validating other compression methods.
 
     Parameters

--- a/kvpress/presses/random_press.py
+++ b/kvpress/presses/random_press.py
@@ -16,37 +16,17 @@ class RandomPress(ScorerPress):
     """
     Random KV cache compression for baseline comparison.
     
-    This method randomly selects which key-value pairs to prune, without considering
-    their importance or attention patterns. It serves as a baseline for comparing
-    the effectiveness of more sophisticated compression methods.
-    
-    While not practical for production use, RandomPress is valuable for:
-    - Establishing baseline performance metrics
-    - Validating that other methods perform better than random selection
-    - Testing compression infrastructure and pipelines
-    - Research and ablation studies
+    Randomly selects which key-value pairs to prune, without considering
+    importance or attention patterns. Useful for establishing baseline
+    performance metrics and validating other compression methods.
     """
 
     compression_ratio: float = 0.0
-    """
-    Fraction of key-value pairs to remove during compression.
-    See ScorerPress.compression_ratio for detailed description.
-    """
+    """Fraction of key-value pairs to remove during compression."""
     
     seed: Optional[int] = None
-    """
-    Random seed for reproducible compression results.
+    """Random seed for reproducible compression results."""
     
-    If provided, this seed is used to initialize the random number generator
-    before selecting which tokens to prune. This ensures that the same input
-    will always result in the same compression pattern.
-    
-    - None: Use default random state (non-reproducible)
-    - Any integer: Use as seed for reproducible results
-    
-    Setting a seed is recommended for research and debugging purposes.
-    """
-
     def score(
         self,
         module: nn.Module,

--- a/kvpress/presses/random_press.py
+++ b/kvpress/presses/random_press.py
@@ -13,10 +13,39 @@ from kvpress.presses.scorer_press import ScorerPress
 
 @dataclass
 class RandomPress(ScorerPress):
-    """Randomly prune KV pairs"""
+    """
+    Random KV cache compression for baseline comparison.
+    
+    This method randomly selects which key-value pairs to prune, without considering
+    their importance or attention patterns. It serves as a baseline for comparing
+    the effectiveness of more sophisticated compression methods.
+    
+    While not practical for production use, RandomPress is valuable for:
+    - Establishing baseline performance metrics
+    - Validating that other methods perform better than random selection
+    - Testing compression infrastructure and pipelines
+    - Research and ablation studies
+    """
 
     compression_ratio: float = 0.0
+    """
+    Fraction of key-value pairs to remove during compression.
+    See ScorerPress.compression_ratio for detailed description.
+    """
+    
     seed: Optional[int] = None
+    """
+    Random seed for reproducible compression results.
+    
+    If provided, this seed is used to initialize the random number generator
+    before selecting which tokens to prune. This ensures that the same input
+    will always result in the same compression pattern.
+    
+    - None: Use default random state (non-reproducible)
+    - Any integer: Use as seed for reproducible results
+    
+    Setting a seed is recommended for research and debugging purposes.
+    """
 
     def score(
         self,

--- a/kvpress/presses/random_press.py
+++ b/kvpress/presses/random_press.py
@@ -15,11 +15,11 @@ from kvpress.presses.scorer_press import ScorerPress
 class RandomPress(ScorerPress):
     """
     Random KV cache compression for baseline comparison.
-    
+
     Randomly selects which key-value pairs to prune, without considering
     importance or attention patterns. Useful for establishing baseline
     performance metrics and validating other compression methods.
-    
+
     Parameters
     ----------
     compression_ratio : float, default=0.0
@@ -30,7 +30,7 @@ class RandomPress(ScorerPress):
 
     compression_ratio: float = 0.0
     seed: Optional[int] = None
-    
+
     def score(
         self,
         module: nn.Module,
@@ -40,6 +40,8 @@ class RandomPress(ScorerPress):
         attentions: torch.Tensor,
         kwargs,
     ) -> torch.Tensor:
+        generator = None
         if self.seed is not None:
-            torch.manual_seed(self.seed)
-        return torch.rand(*keys.shape[:-1]).to(keys.device, keys.dtype)
+            generator = torch.Generator()
+            generator.manual_seed(self.seed)
+        return torch.rand(*keys.shape[:-1], generator=generator, device=keys.device, dtype=keys.dtype)

--- a/kvpress/presses/random_press.py
+++ b/kvpress/presses/random_press.py
@@ -19,13 +19,17 @@ class RandomPress(ScorerPress):
     Randomly selects which key-value pairs to prune, without considering
     importance or attention patterns. Useful for establishing baseline
     performance metrics and validating other compression methods.
+    
+    Parameters
+    ----------
+    compression_ratio : float, default=0.0
+        Fraction of key-value pairs to remove during compression.
+    seed : int, optional
+        Random seed for reproducible compression results.
     """
 
     compression_ratio: float = 0.0
-    """Fraction of key-value pairs to remove during compression."""
-    
     seed: Optional[int] = None
-    """Random seed for reproducible compression results."""
     
     def score(
         self,

--- a/kvpress/presses/scorer_press.py
+++ b/kvpress/presses/scorer_press.py
@@ -17,11 +17,11 @@ logger = logging.getLogger(__name__)
 class ScorerPress(BasePress):
     """
     Base class for score-based KV cache compression methods.
-    
+
     This class provides a framework for compression methods that assign importance scores
     to key-value pairs and prune those with the lowest scores. Subclasses must implement
     the `score` method to define how importance is calculated.
-    
+
     The compression is applied uniformly across all heads and layers based on the
     compression_ratio parameter, which determines what fraction of tokens to remove.
     """
@@ -53,7 +53,7 @@ class ScorerPress(BasePress):
     ) -> torch.Tensor:
         """
         Compute importance scores for each key-value pair.
-        
+
         This method must be implemented by subclasses to define how the importance
         of each token position is calculated. Higher scores indicate more important
         tokens that should be kept during compression.

--- a/kvpress/presses/scorer_press.py
+++ b/kvpress/presses/scorer_press.py
@@ -16,13 +16,28 @@ logger = logging.getLogger(__name__)
 @dataclass
 class ScorerPress(BasePress):
     """
-    Default press method for using a score method.
-    Any ScorerPress subclass must implement the `score` method that computes a tensor of scores for each key-value pair
-    The KV pairs with the lowest scores will be pruned in the `compress` method.
-    The cache is uniformly pruned across all heads and layers using the compression_ratio parameter.
+    Base class for score-based KV cache compression methods.
+    
+    This class provides a framework for compression methods that assign importance scores
+    to key-value pairs and prune those with the lowest scores. Subclasses must implement
+    the `score` method to define how importance is calculated.
+    
+    The compression is applied uniformly across all heads and layers based on the
+    compression_ratio parameter, which determines what fraction of tokens to remove.
     """
 
     compression_ratio: float = 0.0
+    """
+    Fraction of key-value pairs to remove during compression.
+    
+    Must be between 0.0 and 1.0:
+    - 0.0: No compression (keep all tokens)
+    - 0.5: Remove 50% of tokens (keep 50%)
+    - 0.8: Remove 80% of tokens (keep 20%)
+    - 1.0: Remove all tokens (not practical)
+    
+    Higher values result in more aggressive compression but may degrade model performance.
+    """
 
     def __post_init__(self):
         assert 0 <= self.compression_ratio < 1, "Compression ratio must be between 0 and 1"
@@ -37,8 +52,34 @@ class ScorerPress(BasePress):
         kwargs,
     ) -> torch.Tensor:
         """
-        Compute a tensor of scores with shape (bsz, num_key_value_heads, q_len)
-        The KV pairs with lowest scores will be pruned in the `compress` method.
+        Compute importance scores for each key-value pair.
+        
+        This method must be implemented by subclasses to define how the importance
+        of each token position is calculated. Higher scores indicate more important
+        tokens that should be kept during compression.
+
+        Parameters
+        ----------
+        module : nn.Module
+            The transformer attention layer where scoring is applied.
+        hidden_states : torch.Tensor
+            Input embeddings with shape (batch_size, seq_len, hidden_dim).
+        keys : torch.Tensor
+            Key tensors with shape (batch_size, num_kv_heads, seq_len, head_dim).
+        values : torch.Tensor
+            Value tensors with shape (batch_size, num_kv_heads, seq_len, head_dim).
+        attentions : torch.Tensor
+            Attention weights with shape (batch_size, num_heads, seq_len, seq_len).
+            May be None if not computed or needed by the scoring method.
+        kwargs : dict
+            Additional arguments from the forward pass, including cache and position info.
+
+        Returns
+        -------
+        torch.Tensor
+            Importance scores with shape (batch_size, num_kv_heads, seq_len).
+            Higher scores indicate more important tokens. The tokens with the
+            lowest scores will be pruned during compression.
         """
         raise NotImplementedError
 

--- a/kvpress/presses/scorer_press.py
+++ b/kvpress/presses/scorer_press.py
@@ -18,23 +18,16 @@ class ScorerPress(BasePress):
     """
     Base class for score-based KV cache compression methods.
 
-    This class provides a framework for compression methods that assign importance scores
-    to key-value pairs and prune those with the lowest scores. Subclasses must implement
-    the `score` method to define how importance is calculated.
+    This class assigns scores to key-value pairs and prune those with the lowest scores.
+    Subclasses then implement the `score` method to define how importance is calculated.
 
-    The compression is applied uniformly across all heads and layers based on the
-    compression_ratio parameter, which determines what fraction of tokens to remove.
+    Parameters
+    ----------
+    compression_ratio : float, default=0.0
+        Fraction of key-value pairs to remove during compression.
     """
 
     compression_ratio: float = 0.0
-    """
-    Fraction of key-value pairs to remove during compression.
-    Must be between 0.0 and 1.0, e.g.
-    - 0.0: No compression (keep all tokens)
-    - 0.8: Remove 80% of tokens (keep 20%)
-    - 1.0: Remove all tokens (not practical)
-    Higher values result in more aggressive compression but may degrade model performance.
-    """
 
     def __post_init__(self):
         assert 0 <= self.compression_ratio < 1, "Compression ratio must be between 0 and 1"

--- a/kvpress/presses/scorer_press.py
+++ b/kvpress/presses/scorer_press.py
@@ -29,13 +29,10 @@ class ScorerPress(BasePress):
     compression_ratio: float = 0.0
     """
     Fraction of key-value pairs to remove during compression.
-    
-    Must be between 0.0 and 1.0:
+    Must be between 0.0 and 1.0, e.g.
     - 0.0: No compression (keep all tokens)
-    - 0.5: Remove 50% of tokens (keep 50%)
     - 0.8: Remove 80% of tokens (keep 20%)
     - 1.0: Remove all tokens (not practical)
-    
     Higher values result in more aggressive compression but may degrade model performance.
     """
 

--- a/kvpress/presses/simlayerkv_press.py
+++ b/kvpress/presses/simlayerkv_press.py
@@ -18,106 +18,31 @@ class SimLayerKVPress(BasePress):
     """
     SimLayerKV: Similarity-based layer-wise KV cache compression.
     
-    Based on SimLayerKV (https://arxiv.org/abs/2410.13846), this method uses a
-    layer-wise approach to compression by identifying "lazy" layers that can
-    work effectively with reduced KV cache sizes. The method dynamically
-    determines which layers need full context and which can use streaming-style compression.
+    Uses layer-wise approach to compression by identifying "lazy" layers that can
+    work effectively with reduced KV cache sizes. Dynamically determines which
+    layers need full context and which can use streaming-style compression.
+    Based on SimLayerKV (https://arxiv.org/abs/2410.13846).
     
-    The approach works by:
-    1. Analyzing attention patterns of the last tokens in each layer
-    2. Computing attention weight sums over initial and recent tokens
-    3. Identifying layers as "lazy" if their attention is concentrated on recent/initial tokens
-    4. Applying StreamingLLM-style compression to lazy layers (initial + recent tokens only)
-    5. Using full KV cache for non-lazy layers that need complete context
+    Recommended lazy_threshold values: Llama3 (0.9), Llama2 (0.65), Mistral (0.8), Qwen (0.85).
     
-    Layer classification is based on the lazy_threshold parameter:
-    - If sum(attention_weights[last_tokens -> initial+recent]) > lazy_threshold: layer is lazy
-    - Lazy layers use only n_initial + n_recent tokens
-    - Non-lazy layers retain the full KV cache
-    
-    This adaptive approach optimizes memory usage by applying compression only
-    where it won't significantly hurt performance, while preserving full context
-    for layers that need it.
-    
-    Recommended lazy_threshold values from the official repository:
-    - Llama3: 0.9
-    - Llama2: 0.65  
-    - Mistral: 0.8
-    - Qwen: 0.85
-    - Default: 1.0 (no compression, conservative)
+    Parameters
+    ----------
+    lazy_threshold : float, default=1.0
+        Threshold for identifying lazy layers based on attention concentration.
+        Layer is lazy if sum(attention_weights[last_tokens -> initial+recent]) > threshold.
+        Lower values identify more layers as lazy (more aggressive compression).
+    n_last : int, default=1
+        Number of last tokens to analyze for lazy layer identification.
+    n_recent : int, default=1024
+        Number of recent tokens to preserve in lazy layers.
+    n_initial : int, default=4
+        Number of initial tokens to preserve in lazy layers (sink tokens).
     """
 
     lazy_threshold: float = 1.0
-    """
-    Threshold for identifying lazy layers based on attention concentration.
-    
-    This parameter controls which layers are considered "lazy" and can work
-    effectively with reduced KV cache. A layer is classified as lazy if the
-    sum of its last tokens' attention weights over initial and recent tokens
-    exceeds this threshold.
-    
-    Lower thresholds:
-    - Identify more layers as lazy (more aggressive compression)
-    - May reduce memory usage significantly
-    - Risk degrading performance if threshold is too low
-    
-    Higher thresholds:
-    - Identify fewer layers as lazy (more conservative compression)
-    - Preserve more full-context layers
-    - Safer but may not achieve significant memory savings
-    
-    Model-specific recommended values:
-    - 0.65: Llama2 models
-    - 0.8: Mistral models  
-    - 0.85: Qwen models
-    - 0.9: Llama3 models
-    - 1.0: No compression (default, very conservative)
-    """
-    
     n_last: int = 1
-    """
-    Number of last tokens to analyze for lazy layer identification.
-    
-    This parameter specifies how many of the most recent tokens are used
-    to compute attention patterns for layer classification. The attention
-    weights of these tokens are analyzed to determine if a layer focuses
-    primarily on initial and recent tokens.
-    
-    The default value of 1 matches the SKLV-decode configuration and
-    typically provides good layer classification results.
-    """
-    
     n_recent: int = 1024
-    """
-    Number of recent tokens to preserve in lazy layers.
-    
-    For layers identified as lazy, only the most recent n_recent tokens
-    (plus n_initial initial tokens) are retained in the KV cache. This
-    implements a StreamingLLM-style compression for these layers.
-    
-    Larger values:
-    - Preserve more recent context for lazy layers
-    - May improve performance but use more memory
-    - Should be balanced against compression goals
-    
-    Smaller values:
-    - Achieve more aggressive compression in lazy layers
-    - May hurt performance if recent context is important
-    - Provide greater memory savings
-    
-    The default of 1024 provides a reasonable balance for most applications.
-    """
-    
     n_initial: int = 4
-    """
-    Number of initial tokens to preserve in lazy layers (sink tokens).
-    
-    For layers identified as lazy, the first n_initial tokens are always
-    preserved along with the n_recent recent tokens. These serve as
-    attention sinks that help maintain model stability.
-    
-    See StreamingLLMPress.n_sink for detailed description of sink tokens.
-    """
 
     def __post_init__(self):
         assert 0.0 <= self.lazy_threshold <= 1.0, "lazy_threshold should be in [0, 1]"

--- a/kvpress/presses/simlayerkv_press.py
+++ b/kvpress/presses/simlayerkv_press.py
@@ -17,14 +17,14 @@ logger = logging.getLogger(__name__)
 class SimLayerKVPress(BasePress):
     """
     SimLayerKV: Similarity-based layer-wise KV cache compression.
-    
+
     Uses layer-wise approach to compression by identifying "lazy" layers that can
     work effectively with reduced KV cache sizes. Dynamically determines which
     layers need full context and which can use streaming-style compression.
     Based on SimLayerKV (https://arxiv.org/abs/2410.13846).
-    
+
     Recommended lazy_threshold values: Llama3 (0.9), Llama2 (0.65), Mistral (0.8), Qwen (0.85).
-    
+
     Parameters
     ----------
     lazy_threshold : float, default=1.0

--- a/kvpress/presses/simlayerkv_press.py
+++ b/kvpress/presses/simlayerkv_press.py
@@ -21,9 +21,10 @@ class SimLayerKVPress(BasePress):
     Uses layer-wise approach to compression by identifying "lazy" layers that can
     work effectively with reduced KV cache sizes. Dynamically determines which
     layers need full context and which can use streaming-style compression.
-    Based on SimLayerKV (https://arxiv.org/abs/2410.13846).
 
     Recommended lazy_threshold values: Llama3 (0.9), Llama2 (0.65), Mistral (0.8), Qwen (0.85).
+
+    Based on SimLayerKV (https://arxiv.org/abs/2410.13846).
 
     Parameters
     ----------

--- a/kvpress/presses/simlayerkv_press.py
+++ b/kvpress/presses/simlayerkv_press.py
@@ -16,26 +16,108 @@ logger = logging.getLogger(__name__)
 @dataclass
 class SimLayerKVPress(BasePress):
     """
-    SimLayerKV (https://arxiv.org/abs/2410.13846) uses a layer-wise approach to compression:
-        - layers identified as lazy use the Streaming LLM approach (only initial and recent KV pairs are kept)
-        - other layers use the full KV cache
-
-    To identify lazy layers, the last attention weights are used. If the sum of attention weights of the last tokens
-    over the initial and recent tokens is above the lazy_threshold, the layer is considered lazy.
-
-    Recommended values for lazy_threshold from the official repository:
-        - llama3: 0.9
-        - llama2: 0.65
-        - mistral: 0.8
-        - qwen: 0.85
-    By default, lazy_threshold is set to 1.0 (no compression)
-    (Source: https://github.com/sail-sg/SimLayerKV/blob/main/LongBench/pred.py#L167)
+    SimLayerKV: Similarity-based layer-wise KV cache compression.
+    
+    Based on SimLayerKV (https://arxiv.org/abs/2410.13846), this method uses a
+    layer-wise approach to compression by identifying "lazy" layers that can
+    work effectively with reduced KV cache sizes. The method dynamically
+    determines which layers need full context and which can use streaming-style compression.
+    
+    The approach works by:
+    1. Analyzing attention patterns of the last tokens in each layer
+    2. Computing attention weight sums over initial and recent tokens
+    3. Identifying layers as "lazy" if their attention is concentrated on recent/initial tokens
+    4. Applying StreamingLLM-style compression to lazy layers (initial + recent tokens only)
+    5. Using full KV cache for non-lazy layers that need complete context
+    
+    Layer classification is based on the lazy_threshold parameter:
+    - If sum(attention_weights[last_tokens -> initial+recent]) > lazy_threshold: layer is lazy
+    - Lazy layers use only n_initial + n_recent tokens
+    - Non-lazy layers retain the full KV cache
+    
+    This adaptive approach optimizes memory usage by applying compression only
+    where it won't significantly hurt performance, while preserving full context
+    for layers that need it.
+    
+    Recommended lazy_threshold values from the official repository:
+    - Llama3: 0.9
+    - Llama2: 0.65  
+    - Mistral: 0.8
+    - Qwen: 0.85
+    - Default: 1.0 (no compression, conservative)
     """
 
     lazy_threshold: float = 1.0
-    n_last: int = 1  # n_last=1 to match SKLV-decode
+    """
+    Threshold for identifying lazy layers based on attention concentration.
+    
+    This parameter controls which layers are considered "lazy" and can work
+    effectively with reduced KV cache. A layer is classified as lazy if the
+    sum of its last tokens' attention weights over initial and recent tokens
+    exceeds this threshold.
+    
+    Lower thresholds:
+    - Identify more layers as lazy (more aggressive compression)
+    - May reduce memory usage significantly
+    - Risk degrading performance if threshold is too low
+    
+    Higher thresholds:
+    - Identify fewer layers as lazy (more conservative compression)
+    - Preserve more full-context layers
+    - Safer but may not achieve significant memory savings
+    
+    Model-specific recommended values:
+    - 0.65: Llama2 models
+    - 0.8: Mistral models  
+    - 0.85: Qwen models
+    - 0.9: Llama3 models
+    - 1.0: No compression (default, very conservative)
+    """
+    
+    n_last: int = 1
+    """
+    Number of last tokens to analyze for lazy layer identification.
+    
+    This parameter specifies how many of the most recent tokens are used
+    to compute attention patterns for layer classification. The attention
+    weights of these tokens are analyzed to determine if a layer focuses
+    primarily on initial and recent tokens.
+    
+    The default value of 1 matches the SKLV-decode configuration and
+    typically provides good layer classification results.
+    """
+    
     n_recent: int = 1024
+    """
+    Number of recent tokens to preserve in lazy layers.
+    
+    For layers identified as lazy, only the most recent n_recent tokens
+    (plus n_initial initial tokens) are retained in the KV cache. This
+    implements a StreamingLLM-style compression for these layers.
+    
+    Larger values:
+    - Preserve more recent context for lazy layers
+    - May improve performance but use more memory
+    - Should be balanced against compression goals
+    
+    Smaller values:
+    - Achieve more aggressive compression in lazy layers
+    - May hurt performance if recent context is important
+    - Provide greater memory savings
+    
+    The default of 1024 provides a reasonable balance for most applications.
+    """
+    
     n_initial: int = 4
+    """
+    Number of initial tokens to preserve in lazy layers (sink tokens).
+    
+    For layers identified as lazy, the first n_initial tokens are always
+    preserved along with the n_recent recent tokens. These serve as
+    attention sinks that help maintain model stability.
+    
+    See StreamingLLMPress.n_sink for detailed description of sink tokens.
+    """
 
     def __post_init__(self):
         assert 0.0 <= self.lazy_threshold <= 1.0, "lazy_threshold should be in [0, 1]"

--- a/kvpress/presses/simlayerkv_press.py
+++ b/kvpress/presses/simlayerkv_press.py
@@ -18,9 +18,9 @@ class SimLayerKVPress(BasePress):
     """
     SimLayerKV: Similarity-based layer-wise KV cache compression.
 
-    Uses layer-wise approach to compression by identifying "lazy" layers that can
-    work effectively with reduced KV cache sizes. Dynamically determines which
-    layers need full context and which can use streaming-style compression.
+    Identifies "lazy" layers that can work effectively with reduced KV cache sizes.
+    If a layer is considered "lazy", we only keep the initial and recent KV pairs.
+    Otherwise, we keep all KV pairs.
 
     Recommended lazy_threshold values: Llama3 (0.9), Llama2 (0.65), Mistral (0.8), Qwen (0.85).
 

--- a/kvpress/presses/simlayerkv_press.py
+++ b/kvpress/presses/simlayerkv_press.py
@@ -40,7 +40,7 @@ class SimLayerKVPress(BasePress):
     """
 
     lazy_threshold: float = 1.0
-    n_last: int = 1
+    n_last: int = 1  # n_last=1 to match SKLV-decode
     n_recent: int = 1024
     n_initial: int = 4
 

--- a/kvpress/presses/snapkv_press.py
+++ b/kvpress/presses/snapkv_press.py
@@ -19,64 +19,20 @@ from kvpress.presses.scorer_press import ScorerPress
 @dataclass
 class SnapKVPress(ScorerPress):
     """
-    SnapKV: Attention-based KV cache compression using recent token attention patterns.
+    SnapKV: Attention-based KV cache compression using recent token patterns.
     
-    Based on SnapKV (https://arxiv.org/abs/2404.14469), this method uses the attention
-    patterns of the most recent tokens to estimate the importance of previous key-value pairs.
-    The intuition is that tokens which receive high attention from recent queries are likely
-    to be important for future processing.
-    
-    The method computes attention weights between the last `window_size` queries and all
-    previous keys, then applies pooling to obtain importance scores for compression.
-    
-    This approach is particularly effective because:
-    - Recent attention patterns are good predictors of future importance
-    - It avoids the need to store full attention matrices
-    - It works well across different model architectures
+    Uses attention patterns of the most recent tokens to estimate importance
+    of previous key-value pairs. Based on SnapKV (https://arxiv.org/abs/2404.14469).
     """
 
     compression_ratio: float = 0.0
-    """
-    Fraction of key-value pairs to remove during compression.
-    See ScorerPress.compression_ratio for detailed description.
-    """
+    """Fraction of key-value pairs to remove during compression."""
     
     window_size: int = 64
-    """
-    Number of recent tokens to use for computing attention-based importance scores.
-    
-    This parameter controls how many of the most recent query tokens are used to
-    compute attention weights with all previous key tokens. The attention patterns
-    from these recent tokens are used to estimate which older tokens are important.
-    
-    Larger window sizes:
-    - Provide more comprehensive attention patterns
-    - May capture longer-range dependencies better
-    - Require more computation for attention calculation
-    
-    Smaller window sizes:
-    - Are more computationally efficient
-    - Focus on very recent attention patterns
-    - May miss some important long-range dependencies
-    
-    Default value of 64 is based on the original SnapKV paper's recommendations.
-    """
+    """Number of recent tokens to use for computing attention-based importance scores."""
     
     kernel_size: int = 5
-    """
-    Size of the pooling kernel applied to attention weights for smoothing.
-    
-    After computing attention weights between recent queries and all keys, a pooling
-    operation is applied to smooth the attention scores. This helps reduce noise and
-    creates more stable importance estimates.
-    
-    The pooling helps because:
-    - Raw attention weights can be noisy
-    - Smoothing creates more robust importance scores
-    - It reduces the impact of outlier attention values
-    
-    Typical values range from 3 to 7, with 5 being the default from the original paper.
-    """
+    """Size of the pooling kernel applied to attention weights for smoothing."""
 
     @staticmethod
     def compute_window_attention(module, hidden_states, keys, window_size, position_embeddings):

--- a/kvpress/presses/snapkv_press.py
+++ b/kvpress/presses/snapkv_press.py
@@ -22,7 +22,9 @@ class SnapKVPress(ScorerPress):
     SnapKV: Attention-based KV cache compression using recent token patterns.
 
     Uses attention patterns of the most recent tokens to estimate importance
-    of previous key-value pairs. Based on SnapKV (https://arxiv.org/abs/2404.14469).
+    of previous key-value pairs.
+
+    Based on SnapKV (https://arxiv.org/abs/2404.14469).
 
     Parameters
     ----------

--- a/kvpress/presses/snapkv_press.py
+++ b/kvpress/presses/snapkv_press.py
@@ -23,16 +23,20 @@ class SnapKVPress(ScorerPress):
     
     Uses attention patterns of the most recent tokens to estimate importance
     of previous key-value pairs. Based on SnapKV (https://arxiv.org/abs/2404.14469).
+    
+    Parameters
+    ----------
+    compression_ratio : float, default=0.0
+        Fraction of key-value pairs to remove during compression.
+    window_size : int, default=64
+        Number of recent tokens to use for computing attention-based importance scores.
+    kernel_size : int, default=5
+        Size of the pooling kernel applied to attention weights for smoothing.
     """
 
     compression_ratio: float = 0.0
-    """Fraction of key-value pairs to remove during compression."""
-    
     window_size: int = 64
-    """Number of recent tokens to use for computing attention-based importance scores."""
-    
     kernel_size: int = 5
-    """Size of the pooling kernel applied to attention weights for smoothing."""
 
     @staticmethod
     def compute_window_attention(module, hidden_states, keys, window_size, position_embeddings):

--- a/kvpress/presses/snapkv_press.py
+++ b/kvpress/presses/snapkv_press.py
@@ -8,10 +8,10 @@ from dataclasses import dataclass
 import torch
 from torch import nn
 from torch.nn import functional as F
-from transformers.models.llama.modeling_llama import repeat_kv, rotate_half
-from transformers.models.qwen3.modeling_qwen3 import Qwen3Attention
 from transformers.models.gemma3.modeling_gemma3 import Gemma3Attention
+from transformers.models.llama.modeling_llama import repeat_kv, rotate_half
 from transformers.models.phi3.modeling_phi3 import Phi3Attention
+from transformers.models.qwen3.modeling_qwen3 import Qwen3Attention
 
 from kvpress.presses.scorer_press import ScorerPress
 
@@ -20,10 +20,10 @@ from kvpress.presses.scorer_press import ScorerPress
 class SnapKVPress(ScorerPress):
     """
     SnapKV: Attention-based KV cache compression using recent token patterns.
-    
+
     Uses attention patterns of the most recent tokens to estimate importance
     of previous key-value pairs. Based on SnapKV (https://arxiv.org/abs/2404.14469).
-    
+
     Parameters
     ----------
     compression_ratio : float, default=0.0

--- a/kvpress/presses/streaming_llm_press.py
+++ b/kvpress/presses/streaming_llm_press.py
@@ -14,13 +14,13 @@ from kvpress.presses.scorer_press import ScorerPress
 class StreamingLLMPress(ScorerPress):
     """
     StreamingLLM: Window-based KV cache compression with sink tokens.
-    
+
     Implements sliding window approach preserving first few tokens (sink tokens)
     and most recent tokens, while pruning middle tokens. Based on StreamingLLM
     (https://arxiv.org/abs/2309.17453).
-    
+
     Note: For full StreamingLLM behavior, combine with KeyRerotationPress.
-    
+
     Parameters
     ----------
     compression_ratio : float, default=0.0

--- a/kvpress/presses/streaming_llm_press.py
+++ b/kvpress/presses/streaming_llm_press.py
@@ -17,7 +17,6 @@ class StreamingLLMPress(ScorerPress):
 
     Implements sliding window approach preserving first few tokens (sink tokens)
     and most recent tokens, while pruning middle tokens.
-    Note: For full StreamingLLM behavior, combine with KeyRerotationPress.
 
     Based on StreamingLLM (https://arxiv.org/abs/2309.17453).
 

--- a/kvpress/presses/streaming_llm_press.py
+++ b/kvpress/presses/streaming_llm_press.py
@@ -13,17 +13,56 @@ from kvpress.presses.scorer_press import ScorerPress
 @dataclass
 class StreamingLLMPress(ScorerPress):
     """
-    Prune a fixed number of KV pairs at the beginning and end of the sequence (https://arxiv.org/abs/2309.17453)
-    We keep the first n_sink tokens and the last n_local tokens.
-    n_local is computed using the compression ratio.
-
-    Note that the original implementation https://github.com/mit-han-lab/streaming-llm additionally rerotates keys.
-    This can be achieved by using
+    StreamingLLM: Window-based KV cache compression with sink tokens.
+    
+    Based on StreamingLLM (https://arxiv.org/abs/2309.17453), this method implements
+    a sliding window approach that preserves the first few tokens (sink tokens) and
+    the most recent tokens, while pruning tokens in the middle of the sequence.
+    
+    This approach is particularly effective for streaming applications where:
+    - The beginning of the sequence contains important context (sink tokens)
+    - Recent tokens are most relevant for current processing
+    - Middle tokens can be safely discarded to maintain a fixed memory footprint
+    
+    The method works by:
+    1. Always preserving the first n_sink tokens (attention sinks)
+    2. Preserving the last n_local tokens (recent context)
+    3. Pruning all tokens in between these two windows
+    
+    Note: The original StreamingLLM implementation also includes key rerotation.
+    To achieve the full StreamingLLM behavior, combine with KeyRerotationPress:
+    ```python
     press = KeyRerotationPress(press=StreamingLLMPress(compression_ratio, n_sink))
+    ```
     """
 
     compression_ratio: float = 0.0
+    """
+    Fraction of key-value pairs to remove during compression.
+    
+    This determines how many recent tokens (n_local) to keep:
+    n_local = (1 - compression_ratio) * seq_len - n_sink
+    
+    Higher compression ratios result in smaller local windows and more aggressive pruning.
+    See ScorerPress.compression_ratio for detailed description.
+    """
+    
     n_sink: int = 4
+    """
+    Number of initial tokens to always preserve (sink tokens).
+    
+    These tokens at the beginning of the sequence are never pruned, regardless
+    of the compression ratio. They serve as "attention sinks" that help maintain
+    model stability and performance.
+    
+    Typical values:
+    - 4: Default value, works well for most models
+    - 0: No sink tokens (may hurt performance)
+    - 8+: More conservative, preserves more initial context
+    
+    The sink tokens are preserved because language models often assign high
+    attention weights to early tokens regardless of their semantic content.
+    """
 
     def score(
         self,

--- a/kvpress/presses/streaming_llm_press.py
+++ b/kvpress/presses/streaming_llm_press.py
@@ -20,19 +20,20 @@ class StreamingLLMPress(ScorerPress):
     (https://arxiv.org/abs/2309.17453).
     
     Note: For full StreamingLLM behavior, combine with KeyRerotationPress.
+    
+    Parameters
+    ----------
+    compression_ratio : float, default=0.0
+        Fraction of key-value pairs to remove during compression.
+    n_sink : int, default=4
+        Number of initial tokens to always preserve (sink tokens).
+        These tokens are never pruned and serve as "attention sinks" that help
+        maintain model stability. Language models often assign high attention
+        weights to early tokens regardless of semantic content.
     """
 
     compression_ratio: float = 0.0
-    """Fraction of key-value pairs to remove during compression."""
-    
     n_sink: int = 4
-    """
-    Number of initial tokens to always preserve (sink tokens).
-    
-    These tokens are never pruned and serve as "attention sinks" that help
-    maintain model stability. Language models often assign high attention
-    weights to early tokens regardless of semantic content.
-    """
 
     def score(
         self,

--- a/kvpress/presses/streaming_llm_press.py
+++ b/kvpress/presses/streaming_llm_press.py
@@ -15,53 +15,23 @@ class StreamingLLMPress(ScorerPress):
     """
     StreamingLLM: Window-based KV cache compression with sink tokens.
     
-    Based on StreamingLLM (https://arxiv.org/abs/2309.17453), this method implements
-    a sliding window approach that preserves the first few tokens (sink tokens) and
-    the most recent tokens, while pruning tokens in the middle of the sequence.
+    Implements sliding window approach preserving first few tokens (sink tokens)
+    and most recent tokens, while pruning middle tokens. Based on StreamingLLM
+    (https://arxiv.org/abs/2309.17453).
     
-    This approach is particularly effective for streaming applications where:
-    - The beginning of the sequence contains important context (sink tokens)
-    - Recent tokens are most relevant for current processing
-    - Middle tokens can be safely discarded to maintain a fixed memory footprint
-    
-    The method works by:
-    1. Always preserving the first n_sink tokens (attention sinks)
-    2. Preserving the last n_local tokens (recent context)
-    3. Pruning all tokens in between these two windows
-    
-    Note: The original StreamingLLM implementation also includes key rerotation.
-    To achieve the full StreamingLLM behavior, combine with KeyRerotationPress:
-    ```python
-    press = KeyRerotationPress(press=StreamingLLMPress(compression_ratio, n_sink))
-    ```
+    Note: For full StreamingLLM behavior, combine with KeyRerotationPress.
     """
 
     compression_ratio: float = 0.0
-    """
-    Fraction of key-value pairs to remove during compression.
-    
-    This determines how many recent tokens (n_local) to keep:
-    n_local = (1 - compression_ratio) * seq_len - n_sink
-    
-    Higher compression ratios result in smaller local windows and more aggressive pruning.
-    See ScorerPress.compression_ratio for detailed description.
-    """
+    """Fraction of key-value pairs to remove during compression."""
     
     n_sink: int = 4
     """
     Number of initial tokens to always preserve (sink tokens).
     
-    These tokens at the beginning of the sequence are never pruned, regardless
-    of the compression ratio. They serve as "attention sinks" that help maintain
-    model stability and performance.
-    
-    Typical values:
-    - 4: Default value, works well for most models
-    - 0: No sink tokens (may hurt performance)
-    - 8+: More conservative, preserves more initial context
-    
-    The sink tokens are preserved because language models often assign high
-    attention weights to early tokens regardless of their semantic content.
+    These tokens are never pruned and serve as "attention sinks" that help
+    maintain model stability. Language models often assign high attention
+    weights to early tokens regardless of semantic content.
     """
 
     def score(

--- a/kvpress/presses/streaming_llm_press.py
+++ b/kvpress/presses/streaming_llm_press.py
@@ -16,10 +16,10 @@ class StreamingLLMPress(ScorerPress):
     StreamingLLM: Window-based KV cache compression with sink tokens.
 
     Implements sliding window approach preserving first few tokens (sink tokens)
-    and most recent tokens, while pruning middle tokens. Based on StreamingLLM
-    (https://arxiv.org/abs/2309.17453).
-
+    and most recent tokens, while pruning middle tokens.
     Note: For full StreamingLLM behavior, combine with KeyRerotationPress.
+
+    Based on StreamingLLM (https://arxiv.org/abs/2309.17453).
 
     Parameters
     ----------

--- a/kvpress/presses/think_press.py
+++ b/kvpress/presses/think_press.py
@@ -6,10 +6,10 @@ from dataclasses import dataclass
 
 import torch
 from torch import nn
-from transformers.models.llama.modeling_llama import rotate_half
-from transformers.models.qwen3.modeling_qwen3 import Qwen3Attention
 from transformers.models.gemma3.modeling_gemma3 import Gemma3Attention
+from transformers.models.llama.modeling_llama import rotate_half
 from transformers.models.phi3.modeling_phi3 import Phi3Attention
+from transformers.models.qwen3.modeling_qwen3 import Qwen3Attention
 
 from kvpress.presses.base_press import BasePress
 
@@ -18,11 +18,11 @@ from kvpress.presses.base_press import BasePress
 class ThinKPress(BasePress):
     """
     ThinK: Channel-wise key compression for transformer attention.
-    
+
     Compresses key dimensions rather than sequence length by zeroing out
     less important channels. Based on ThinK (https://arxiv.org/pdf/2407.21018).
     Can be combined with sequence compression methods.
-    
+
     Parameters
     ----------
     key_channel_compression_ratio : float, default=0.0
@@ -44,11 +44,11 @@ class ThinKPress(BasePress):
 
         # Get last self.window_size queries
         if isinstance(module, Phi3Attention):
-            qkv = module.qkv_proj(hidden_states[:, -self.window_size:])
+            qkv = module.qkv_proj(hidden_states[:, -self.window_size :])
             query_states = qkv[..., : num_heads * head_dim]
         elif hasattr(module, "q_proj"):
             # Assume Llama-like attention layer
-            query_states = module.q_proj(hidden_states[:, -self.window_size:])
+            query_states = module.q_proj(hidden_states[:, -self.window_size :])
         else:
             raise NotImplementedError(f"SnapKV not yet implemented for {module.__class__}.")
 

--- a/kvpress/presses/think_press.py
+++ b/kvpress/presses/think_press.py
@@ -19,8 +19,15 @@ class ThinKPress(BasePress):
     """
     ThinK: Channel-wise key compression for transformer attention.
 
-    Compresses key dimensions rather than sequence length by zeroing out
-    less important channels. Can be combined with sequence compression methods.
+    ThinK compresses the dimensions of the keys, and not the sequence length.
+    Hence it can be combined with any other press that compresses the sequence length, e.g.
+    press = ComposedPress([SnapKVPress(0.5), ThinKPress(0.5)])
+
+    Here, we zero out the pruned dimensions resulting in no memory gain (the shape of the keys remains the same).
+    To achieve memory savings, several options can be considered (see https://github.com/NVIDIA/kvpress/pull/18/),
+    we might implement them in the future, especially if other similar presses are requested.
+
+    This press has been reviewed by Yuhui Xu, first author of the ThinK paper.
 
     Based on ThinK (https://arxiv.org/pdf/2407.21018).
 

--- a/kvpress/presses/think_press.py
+++ b/kvpress/presses/think_press.py
@@ -20,8 +20,9 @@ class ThinKPress(BasePress):
     ThinK: Channel-wise key compression for transformer attention.
 
     Compresses key dimensions rather than sequence length by zeroing out
-    less important channels. Based on ThinK (https://arxiv.org/pdf/2407.21018).
-    Can be combined with sequence compression methods.
+    less important channels. Can be combined with sequence compression methods.
+
+    Based on ThinK (https://arxiv.org/pdf/2407.21018).
 
     Parameters
     ----------

--- a/kvpress/presses/think_press.py
+++ b/kvpress/presses/think_press.py
@@ -19,63 +19,20 @@ class ThinKPress(BasePress):
     """
     ThinK: Channel-wise key compression for transformer attention.
     
-    Based on ThinK (https://arxiv.org/pdf/2407.21018), this method compresses the dimensions
-    of the keys rather than the sequence length. Unlike other methods that remove entire
-    tokens, ThinK reduces the dimensionality of each key vector by zeroing out less
-    important channels.
+    Compresses key dimensions rather than sequence length by zeroing out
+    less important channels. Based on ThinK (https://arxiv.org/pdf/2407.21018).
+    Can be combined with sequence compression methods.
     
-    This approach is complementary to sequence-length compression methods and can be
-    combined with them for even greater compression. For example:
-    ```python
-    press = ComposedPress([SnapKVPress(0.5), ThinKPress(0.5)])
-    ```
-    
-    Key characteristics:
-    - Compresses key dimensions, not sequence length
-    - Can be combined with other compression methods
-    - Uses recent query patterns to identify important key channels
-    - Currently zeros out pruned dimensions (no memory savings in this implementation)
-    
-    Note: This implementation zeros out pruned dimensions rather than removing them,
-    so memory usage remains the same while computation may be reduced.
-    
-    This press has been reviewed by Yuhui Xu, first author of the ThinK paper.
+    Parameters
+    ----------
+    key_channel_compression_ratio : float, default=0.0
+        Fraction of key channels (dimensions) to remove during compression.
+    window_size : int, default=32
+        Number of recent tokens to use for computing key channel importance.
     """
 
     key_channel_compression_ratio: float = 0.0
-    """
-    Fraction of key channels (dimensions) to remove during compression.
-    
-    Must be between 0.0 and 1.0:
-    - 0.0: No compression (keep all key dimensions)
-    - 0.3: Remove 30% of key channels (keep 70%)
-    - 0.7: Remove 70% of key channels (keep 30%)
-    
-    Unlike sequence compression, this affects the dimensionality of each key vector
-    rather than the number of tokens. Higher values result in more aggressive
-    dimensional reduction but may impact attention quality.
-    """
-    
     window_size: int = 32
-    """
-    Number of recent tokens to use for computing key channel importance.
-    
-    This parameter determines how many of the most recent query tokens are used
-    to compute attention patterns with keys, which helps identify which key
-    channels are most important for recent attention computations.
-    
-    Larger window sizes:
-    - Provide more comprehensive patterns for channel importance
-    - May better capture which dimensions are consistently important
-    - Require more computation for the importance analysis
-    
-    Smaller window sizes:
-    - Are more computationally efficient
-    - Focus on very recent attention patterns
-    - May miss some important channel dependencies
-    
-    Default value of 32 provides a good balance between accuracy and efficiency.
-    """
 
     def compute_window_queries(self, module, hidden_states, position_embeddings):
         """

--- a/kvpress/presses/tova_press.py
+++ b/kvpress/presses/tova_press.py
@@ -16,12 +16,12 @@ from kvpress.presses.snapkv_press import SnapKVPress
 class TOVAPress(ScorerPress):
     """
     TOVA: Token-wise Optimal Value Attention for KV cache compression.
-    
+
     Uses attention weights of the last token (averaged across heads) to estimate
     importance of previous key-value pairs. The last token's attention pattern
     provides a good indicator of which historical tokens are important.
     Based on TOVA (https://arxiv.org/abs/2401.06104).
-    
+
     Parameters
     ----------
     compression_ratio : float, default=0.0

--- a/kvpress/presses/tova_press.py
+++ b/kvpress/presses/tova_press.py
@@ -20,6 +20,7 @@ class TOVAPress(ScorerPress):
     Uses attention weights of the last token (averaged across heads) to estimate
     importance of previous key-value pairs. The last token's attention pattern
     provides a good indicator of which historical tokens are important.
+
     Based on TOVA (https://arxiv.org/abs/2401.06104).
 
     Parameters

--- a/kvpress/presses/tova_press.py
+++ b/kvpress/presses/tova_press.py
@@ -22,6 +22,7 @@ class TOVAPress(ScorerPress):
     provides a good indicator of which historical tokens are important.
 
     Based on TOVA (https://arxiv.org/abs/2401.06104).
+    Official implementation can be found here: https://github.com/schwartz-lab-NLP/TOVA/blob/main/src/tova_cache.py
 
     Parameters
     ----------

--- a/kvpress/presses/tova_press.py
+++ b/kvpress/presses/tova_press.py
@@ -21,10 +21,14 @@ class TOVAPress(ScorerPress):
     importance of previous key-value pairs. The last token's attention pattern
     provides a good indicator of which historical tokens are important.
     Based on TOVA (https://arxiv.org/abs/2401.06104).
+    
+    Parameters
+    ----------
+    compression_ratio : float, default=0.0
+        Fraction of key-value pairs to remove during compression.
     """
 
     compression_ratio: float = 0.0
-    """Fraction of key-value pairs to remove during compression."""
 
     def score(
         self,

--- a/kvpress/presses/tova_press.py
+++ b/kvpress/presses/tova_press.py
@@ -17,34 +17,14 @@ class TOVAPress(ScorerPress):
     """
     TOVA: Token-wise Optimal Value Attention for KV cache compression.
     
-    Based on TOVA (https://arxiv.org/abs/2401.06104), this method uses the attention
-    weights of the last token (averaged across all attention heads) to estimate the
-    importance of previous key-value pairs. The intuition is that the attention pattern
-    of the most recent token provides a good indicator of which historical tokens
-    are important for the current context.
-    
-    The method works by:
-    1. Computing attention weights between the last query and all previous keys
-    2. Averaging these attention weights across all attention heads
-    3. Using the averaged attention as importance scores for compression
-    4. Adding back the last token with maximum score to ensure it's never pruned
-    
-    This approach is particularly effective because:
-    - The last token's attention pattern reflects current context needs
-    - Averaging across heads provides a robust importance estimate
-    - It's computationally efficient (only requires one attention computation)
-    - It naturally handles different types of attention patterns
-    
-    This implementation has been reviewed by Michael Hassid, one of the authors
-    of the TOVA paper. Official implementation: 
-    https://github.com/schwartz-lab-NLP/TOVA/blob/main/src/tova_cache.py
+    Uses attention weights of the last token (averaged across heads) to estimate
+    importance of previous key-value pairs. The last token's attention pattern
+    provides a good indicator of which historical tokens are important.
+    Based on TOVA (https://arxiv.org/abs/2401.06104).
     """
 
     compression_ratio: float = 0.0
-    """
-    Fraction of key-value pairs to remove during compression.
-    See ScorerPress.compression_ratio for detailed description.
-    """
+    """Fraction of key-value pairs to remove during compression."""
 
     def score(
         self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "kvpress"
 authors = ["Simon Jegou", "Maximilian Jeblick", "Jiwei Liu", "David Austin"]
 description = "Efficiently compress the KV cache of any pretrained transformer"
-version = "0.2.6"
+version = "0.2.7"
 readme = "README.md"
 
 [tool.poetry.dependencies]

--- a/tests/default_presses.py
+++ b/tests/default_presses.py
@@ -6,17 +6,17 @@ import numpy as np
 from kvpress import (
     DuoAttentionPress,
     ExpectedAttentionPress,
+    KeyDiffPress,
     KnormPress,
+    LagKVPress,
+    PyramidKVPress,
+    QFilterPress,
     RandomPress,
     SimLayerKVPress,
     SnapKVPress,
     StreamingLLMPress,
     ThinKPress,
     TOVAPress,
-    QFilterPress,
-    PyramidKVPress,
-    LagKVPress,
-    KeyDiffPress,
 )
 
 
@@ -63,7 +63,7 @@ default_presses = [
         "cls": LagKVPress,
         "kwargs": [
             {"compression_ratio": 0.5, "n_sink": 16, "lag_size": 128},
-            {"compression_ratio": 0.8, "n_sink": 16, "lag_size": 128}
+            {"compression_ratio": 0.8, "n_sink": 16, "lag_size": 128},
         ],
     },
     {"cls": KeyDiffPress, "kwargs": [{"compression_ratio": 0.2}, {"compression_ratio": 0.8}]},

--- a/tests/presses/test_block_press.py
+++ b/tests/presses/test_block_press.py
@@ -7,9 +7,8 @@ import torch
 import torch.nn as nn
 from transformers import DynamicCache
 
-from kvpress.presses.scorer_press import ScorerPress
 from kvpress.presses.block_press import BlockPress
-
+from kvpress.presses.scorer_press import ScorerPress
 from tests.fixtures import unit_test_model  # noqa: F401
 
 


### PR DESCRIPTION
## PR description

Add verbose documentation for all presses.
Also fixed some minor issues in the README.
Remaining code changes are coming from `make format`. IMO, it could make sense to add a github action that check `make format` doesn't format the code again (i.e. it is already formatted).

Fixes #88 

## Checklist

- Tests are working (make test)
- Code is formatted correctly (make style, on errors try fix with make format)
- Copyright header is included
- [X] All commits are signed-off  using `git commit -s`
- [ ] (new press) `mypress_press.py` is in the `presses` directory
- [ ] (new press) `MyPress` is in `__init__.py` 
- [ ] (new press) `README.md` is updated with a 1 liner about the new press in the Available presses section
- [ ] (new press) new press is in the `default_presses` list in `tests/default_presses.py`
