### PR TITLE
Add KVzipPress

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Some presses rely on a different logic:
 - `SimLayerKVPress` ([source](kvpress/presses/simlayerkv_press.py), [paper](https://arxiv.org/abs/2410.13846)): identify "lazy" layers, and apply the StreamingLLM approach to them 
 - `DuoAttentionPress` ([source](kvpress/presses/duo_attention_press.py), [paper](https://arxiv.org/abs/2410.10819)): split heads into retrieval heads (no compression) and streaming heads (StreamingLLM approach)
 - `FinchPress` ([source](kvpress/presses/finch_press.py), [paper](https://direct.mit.edu/tacl/article/doi/10.1162/tacl_a_00716/125280)): similar to SnapKV with a dynamic window size and key value re-rotation
+- `KVzipPress` ([source](kvpress/presses/kvzip_press.py), [paper](https://arxiv.org/abs/2505.23416)): accurately identifies redundant KV pairs through context reconstruction, achieving near-lossless query-agnostic compression at eviction ratios of up to 70–80%.
 
 Finally we provide wrapper presses that can be combined with other presses:
 - `AdaKVPress` ([source](kvpress/presses/adakv_press.py), [paper](https://arxiv.org/abs/2407.11550)): prune bottom scores of any `ScorerPress` but across all heads, achieving head-wise compressions 

--- a/evaluation/evaluate.py
+++ b/evaluation/evaluate.py
@@ -37,6 +37,7 @@ from kvpress import (
     StreamingLLMPress,
     ThinKPress,
     TOVAPress,
+    KVzipPress,
 )
 
 logger = logging.getLogger(__name__)
@@ -84,13 +85,14 @@ PRESS_DICT = {
     "snap_think": ComposedPress([SnapKVPress(), ThinKPress()]),
     "pyramidkv": PyramidKVPress(),
     "finch": FinchPress(),
+    "kvzip": KVzipPress(),
 }
 
 
 def evaluate(
     dataset: str,
     data_dir: Optional[str] = None,
-    model: str = "meta-llama/Meta-Llama-3.1-8B-Instruct",
+    model: str = "meta-llama/Llama-3.1-8B-Instruct",
     device: Optional[str] = None,
     press_name: str = "expected_attention",
     compression_ratio: float = 0.1,
@@ -110,7 +112,7 @@ def evaluate(
     data_dir : str, optional
         Subdirectory of the dataset to evaluate, by default None
     model : str, optional
-        Model to use, by default "meta-llama/Meta-Llama-3.1-8B-Instruct"
+        Model to use, by default "meta-llama/Llama-3.1-8B-Instruct"
     device : str, optional
         Model device, by default cuda:0 if available else cpu. For multi-GPU use "auto"
     press_name : str, optional

--- a/evaluation/evaluate.sh
+++ b/evaluation/evaluate.sh
@@ -1,8 +1,8 @@
 dataset="ruler"
 data_dir="4096"
-model="meta-llama/Meta-Llama-3.1-8B-Instruct"
-compression_ratios=(0.1 0.25 0.5)
-press_names=("expected_attention" "knorm" "streaming_llm" "snapkv")
+model="meta-llama/Llama-3.1-8B-Instruct"
+compression_ratios=(0.1 0.25 0.5 0.75)
+press_names=("expected_attention" "knorm" "streaming_llm" "snapkv" "kvzip")
 
 # Check if the number of press names is less than or equal to the number of available GPUs
 num_gpus=$(nvidia-smi --list-gpus | wc -l)

--- a/kvpress/__init__.py
+++ b/kvpress/__init__.py
@@ -28,6 +28,7 @@ from kvpress.presses.pyramidkv_press import PyramidKVPress
 from kvpress.presses.finch_press import FinchPress
 from kvpress.presses.lagkv_press import LagKVPress
 from kvpress.presses.base_press import SUPPORTED_MODELS
+from kvpress.presses.kvzip_press import KVzipPress
 
 # Patch the attention functions to support head-wise compression
 patch_attention_functions()
@@ -58,4 +59,5 @@ __all__ = [
     "PyramidKVPress",
     "FinchPress",
     "LagKVPress",
+    "KVzipPress",
 ]

--- a/kvpress/presses/kvzip_press.py
+++ b/kvpress/presses/kvzip_press.py
@@ -1,0 +1,273 @@
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from dataclasses import dataclass
+import math
+
+import torch
+from torch import nn
+from transformers import PreTrainedTokenizer, PreTrainedModel, Gemma3ForCausalLM
+from transformers import QuantizedCache
+from transformers.models.llama.modeling_llama import rotate_half
+from transformers.models.qwen3.modeling_qwen3 import Qwen3Attention
+from transformers.models.gemma3.modeling_gemma3 import Gemma3Attention
+from transformers.models.phi3.modeling_phi3 import Phi3Attention
+
+from kvpress.presses.base_press import BasePress
+
+
+@dataclass
+class KVzipPress(BasePress):
+    """
+    KVzip identifies the importance of KV pairs through context reconstruction, enabling effective query-agnostic KV cache compression.
+    In this code, we implement KVzip with minimal changes to this repository.
+    
+    For a fully optimized implementation with actual compression, please refer to the original repository. 
+    The original repository also provides a version without runtime compression overhead (at the cost of performance).
+
+    Original repo: https://github.com/snu-mllab/KVzip 
+    Paper: https://arxiv.org/abs/2505.23416    
+    """
+
+    compression_ratio: float = 0.0
+    layerwise: bool = False  # True sets uniform compression ratios across layers 
+    n_sink: int = 4  
+    
+    do_compress: bool = False
+    context: str = None
+    suffix: str = None    
+    context_length: int = 0
+    start_idx: int = 0    
+    end_idx: int = 0    
+
+    score_val: torch.Tensor = None
+    causal_mask_score: torch.Tensor = None
+        
+
+    def _chunk_fn(self, ctx_ids: torch.Tensor, chunk_size: int):
+        """ Chunk input tokens
+        """
+        ctx_len = ctx_ids.shape[1]
+        if ctx_len > chunk_size:
+            chunk_num = (ctx_len - 1) // chunk_size + 1
+
+            input_ids = []
+            for i in range(chunk_num):
+                start = i * chunk_size
+                end = (i + 1) * chunk_size
+                a_ids = ctx_ids[:, start:end]
+                if a_ids.shape[1] == 0:
+                    continue
+                input_ids.append(a_ids)
+        else:
+            input_ids = [ctx_ids]
+
+        return input_ids
+
+
+    def prepare(
+        self,
+        model: PreTrainedModel,
+        tokenizer: PreTrainedTokenizer,
+        full_context_length: int,
+        chunk_size: int = 2048,
+        prev_postfix_size=8,
+    ):
+        """ Prepare chunked inputs for KV importance scoring with context reconstruction
+            return: List[torch.Tensor]
+        """
+
+        ctx_ids = tokenizer.encode(self.context, return_tensors="pt", add_special_tokens=False)
+        suffix_ids = tokenizer.encode(self.suffix, return_tensors="pt", add_special_tokens=False)
+
+        self.context_length = full_context_length
+        self.start_idx = full_context_length - ctx_ids.shape[1]  # the length of a system prompt
+
+        # initialize score values 
+        n_layers, n_kv = model.config.num_hidden_layers, model.config.num_key_value_heads
+        self.score_val = torch.zeros((n_layers, 1, n_kv, full_context_length),  # only support batch size of 1
+                        dtype=model.dtype, 
+                        device=model.device)
+        self.score_val[..., :self.n_sink] = 1.
+        
+                
+        input_ids = []
+        chunked_inputs = self._chunk_fn(ctx_ids, chunk_size)
+        for i, a_ids in enumerate(chunked_inputs):
+            if i == 0:
+                prompt = f"\n\nRepeat the previous context exactly."
+                q_ids = tokenizer.encode(prompt, return_tensors="pt", add_special_tokens=False)
+            else:
+                prompt = f"\n\nRepeat the part of the previous context exactly, starting with"
+                q_ids = tokenizer.encode(prompt, return_tensors="pt", add_special_tokens=False)
+                postfix_prev = chunked_inputs[i - 1][:, -prev_postfix_size:]
+                q_ids = torch.cat([q_ids, postfix_prev], dim=1)
+
+            input_ids.append((a_ids, torch.cat([q_ids, suffix_ids, a_ids], dim=1)))
+
+        return input_ids
+    
+
+    def forward_hook(self, module: nn.Module, input: list[torch.Tensor], kwargs: dict, output: list):
+        """
+        Overwrite the forward_hook of BasePress
+        """
+
+        hidden_states = kwargs["hidden_states"]
+        cache = kwargs["past_key_value"]
+        q_len = hidden_states.shape[1]
+
+        # Modified condition 
+        if not self.do_compress:
+            return output
+
+        if isinstance(cache, QuantizedCache):
+            keys = cache._dequantize(cache._quantized_key_cache[module.layer_idx])
+            values = cache._dequantize(cache._quantized_value_cache[module.layer_idx])
+        else:
+            keys = cache.key_cache[module.layer_idx]
+            values = cache.value_cache[module.layer_idx]
+
+        # Only do scoring. Compression is done afterward by press.compress(self.model) in pipeline.py.
+        keys, values = self.score(module, hidden_states, keys, values, output[1], kwargs)
+
+        if isinstance(cache, QuantizedCache):
+            cache._quantized_key_cache[module.layer_idx] = cache._quantize(keys, axis=cache.axis_key)
+            cache._quantized_value_cache[module.layer_idx] = cache._quantize(values, axis=cache.axis_value)
+            cache.key_cache[module.layer_idx] = torch.zeros(0, dtype=keys.dtype, device=keys.device)
+            cache.value_cache[module.layer_idx] = torch.zeros(0, dtype=keys.dtype, device=keys.device)
+            cache._seen_tokens = keys.shape[2]
+        else:
+            cache.key_cache[module.layer_idx] = keys
+            cache.value_cache[module.layer_idx] = values
+
+        return output
+
+
+    def _make_mask(self, attn_weights: torch.Tensor, window_size: int):
+        """ 
+        Define causal mask shared across layers
+        """
+        mask = torch.full((window_size, window_size),
+                          torch.finfo(attn_weights.dtype).min,
+                          device=attn_weights.device)
+        mask_cond = torch.arange(mask.size(-1), device=attn_weights.device)
+        mask.masked_fill_(mask_cond < (mask_cond + 1).view(mask.size(-1), 1), 0)
+        self.causal_mask_score = mask[None, None, None, :, :]
+        
+
+    def _mask_causal(self, attn_weights: torch.Tensor, window_size: int):
+        """ 
+        Apply causal maksing
+        """
+        if self.causal_mask_score is None:
+            self._make_mask(attn_weights, window_size)
+        elif self.causal_mask_score.size(-1) != window_size:
+            self._make_mask(attn_weights, window_size)
+
+        attn_weights[..., -window_size:, -window_size:] += self.causal_mask_score
+        
+
+    def score(
+        self,
+        module: nn.Module,
+        hidden_states: torch.Tensor,
+        keys: torch.Tensor,
+        values: torch.Tensor,
+        attentions: torch.Tensor,
+        kwargs,
+    ) -> torch.Tensor:
+        """
+        Compute the max cross-attention scores during the context reconstruction.
+        """
+
+        bsz, q_len, _ = hidden_states.shape
+        num_heads = module.config.num_attention_heads
+        num_heads_kv = module.config.num_key_value_heads
+        head_dim = module.head_dim
+        num_key_value_groups = num_heads // num_heads_kv
+
+        if isinstance(module, Phi3Attention):
+            qkv = module.qkv_proj(hidden_states)
+            queries = qkv[..., : num_heads * head_dim]
+        elif hasattr(module, "q_proj"):
+            # Assume Llama-like attention layer
+            queries = module.q_proj(hidden_states)
+        else:
+            raise NotImplementedError(f"SnapKV not yet implemented for {module.__class__}.")
+
+        queries = queries.view(bsz, q_len, num_heads, head_dim).transpose(1, 2)
+
+        # Support for Qwen3 and Gemma3 QK norm
+        if isinstance(module, (Qwen3Attention, Gemma3Attention)):
+            queries = module.q_norm(queries)
+
+        # Apply RoPE
+        cos, sin = kwargs["position_embeddings"]
+        queries = (queries * cos.unsqueeze(1)) + (rotate_half(queries) * sin.unsqueeze(1))
+        queries = queries.view(bsz, num_heads_kv, num_key_value_groups, q_len, head_dim)
+        
+        # Subsample keys
+        sink = min(self.n_sink, self.start_idx) 
+        ctx_len = self.end_idx - self.start_idx
+        keys_subsampled = torch.cat(
+            [
+                keys[:, :, :sink],  # attention sink tokens (generally system prompt)
+                keys[:, :, self.start_idx:self.end_idx],  # KV chunk in the cache
+                keys[:, :, -q_len:],  # KV repeat chunk
+            ],
+            dim=2)        
+        keys_subsampled = keys_subsampled.unsqueeze(2).transpose(-2, -1).contiguous()
+
+        # Compute attention
+        attn_weights = torch.matmul(queries, keys_subsampled) / math.sqrt(head_dim)
+        self._mask_causal(attn_weights, q_len)
+        attn_weights = nn.functional.softmax(attn_weights, dim=-1)
+        
+        attn_weights = attn_weights[..., sink:sink + ctx_len]
+        scores = attn_weights.amax(dim=(-3, -2))  # max over group, q
+        
+        self.score_val[module.layer_idx][..., self.start_idx:self.end_idx] = scores
+
+        keys, values = keys[:,:,:self.context_length], values[:,:,:self.context_length]        
+        return keys, values
+            
+
+    def compress(self, model: PreTrainedModel):
+        """
+        Adopted from adakv_press.compress (fake compression). KVzip does not rely on safeguards. 
+        """
+        if self.compression_ratio > 0:
+            n_layer, bsz, num_key_value_heads, ctx_len = self.score_val.shape
+
+            # calculate the pruned KV pairs across layers
+            if self.layerwise:
+                n_pruned = int(num_key_value_heads * ctx_len * self.compression_ratio)
+                n_pruned_layers = n_pruned * torch.ones(n_layer, device=self.score_val.device, dtype=torch.int)
+            else:
+                score_sort = torch.sort(self.score_val.reshape(-1)).values  # ascending order
+                n = max(int(len(score_sort) * self.compression_ratio) - 1, 0)
+                thres = score_sort[n].item()
+
+                n_pruned_layers = (self.score_val.reshape(n_layer, -1) <= thres).sum(-1)  # n_prune
+            
+            for layer in model.model.layers:
+                if isinstance(model, Gemma3ForCausalLM) and layer.is_sliding:
+                    # Skip layers with sliding window attention, only for Gemma3
+                    continue
+                module = layer.self_attn
+                
+                assert module.config._attn_implementation != "eager", "eager mode not supported"       
+         
+                scores = self.score_val[module.layer_idx]
+
+                # Compute bottom-k across heads
+                n_pruned = n_pruned_layers[module.layer_idx]
+                indices = torch.topk(-scores.reshape(bsz, -1), n_pruned, dim=1).indices.flatten()
+
+                # Save indices to mask during the attention mechanism. Please refer to attention_patch.py for more details
+                batch_indices = torch.arange(bsz, device=n_pruned.device).repeat_interleave(n_pruned)
+                head_indices = indices // ctx_len
+                seq_indices = indices % ctx_len
+                module.masked_key_indices = (batch_indices, head_indices, seq_indices)
+                

--- a/tests/default_presses.py
+++ b/tests/default_presses.py
@@ -16,6 +16,7 @@ from kvpress import (
     QFilterPress,
     PyramidKVPress,
     LagKVPress,
+    KVzipPress,
 )
 
 
@@ -63,6 +64,13 @@ default_presses = [
         "kwargs": [
             {"compression_ratio": 0.5, "n_sink": 16, "lag_size": 128},
             {"compression_ratio": 0.8, "n_sink": 16, "lag_size": 128}
+        ],
+    },
+    {
+        "cls": KVzipPress,
+        "kwargs": [
+            {"compression_ratio": 0.5},
+            {"compression_ratio": 0.8}
         ],
     },
 ]

--- a/tests/presses/test_kvzip_press.py
+++ b/tests/presses/test_kvzip_press.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+
+from kvpress import KVzipPress
+from tests.fixtures import unit_test_model  # noqa: F401
+
+from transformers import DynamicCache, AutoTokenizer
+import random
+
+
+def test_kvzip_press(unit_test_model):  # noqa: F811
+    tokenizer = AutoTokenizer.from_pretrained("MaxJeblick/llama2-0b-unit-test")
+    compression_ratio = 0.7
+    
+    for press in [
+        KVzipPress(compression_ratio),
+        KVzipPress(compression_ratio, layerwise=True),  # uniform compression ratios across layers
+    ]:
+
+        words = ["alpha", "beta", "gamma", "delta", "epsilon"]
+        context = " ".join(random.choices(words, k=3000))  # dummy text
+        context_ids = tokenizer.encode(context, return_tensors="pt", add_special_tokens=False)
+        context_length = context_ids.shape[1]
+
+        press.context = context
+        press.suffix = "Dummy"
+
+        # Test initial prefill
+        cache = DynamicCache()
+        with press(unit_test_model):
+            unit_test_model(
+                input_ids=context_ids,
+                past_key_values=cache,
+                num_logits_to_keep=1,
+            )
+
+        # Test scoring
+        press.do_compress = True            
+        with press(unit_test_model):
+            input_ids = press.prepare(unit_test_model, tokenizer, context_length)  # chunkes of the repeated context
+            for prefill_ids, repeat_ids in input_ids:
+                press.end_idx = press.start_idx + prefill_ids.shape[1]                     
+                unit_test_model(
+                    input_ids=repeat_ids.to(unit_test_model.device),
+                    past_key_values=cache,
+                    num_logits_to_keep=1,
+                )  
+                press.start_idx = press.end_idx
+        assert press.end_idx == context_length, print("tokenization is not consistent")
+
+        # Test compression
+        press.compress(unit_test_model)
+        press.do_compress = False
+
+        n_kv_full = 0
+        for keys in cache.key_cache:
+            n_kv_full += keys[..., 0].numel()  # head_dim dimension
+            
+        assert cache.key_cache[0].shape[-2] == context_length, \
+            print("cache seq_length does not match the original context_length")
+
+        n_pruned = 0
+        for layer in unit_test_model.model.layers:
+            module = layer.self_attn
+            batch_indices, head_indices, seq_indices = module.masked_key_indices            
+            n_pruned += len(seq_indices)
+        
+        pruned_ratio = n_pruned / n_kv_full
+
+        # Allow up to 0.1% error
+        tolerance = 0.001  # 0.1%
+        assert abs(pruned_ratio - compression_ratio) <= tolerance, \
+            f"pruned: {pruned_ratio:.3f}, setting: {compression_ratio:.3f}"
+            


### PR DESCRIPTION
## PR description

Hi! I've tried to add **KVzip**, a recent work on query-agnostic KV cache eviction. 
- arXiv: https://arxiv.org/abs/2505.23416  
- Code: https://github.com/snu-mllab/KVzip 

KVzip achieves near-lossless compression at **eviction ratios of up to 80%** on RULER-4k with LLaMA3.1-8B (evaluated using the evaluation.py script from this repository). I've uploaded the result json files on [Drive](https://drive.google.com/drive/folders/1whGKe5q-U_EmJsU03PVx39SvLulWHiIs?usp=share_link).

<img width="502" alt="Screenshot 2025-07-08 at 10 50 42 AM" src="https://github.com/user-attachments/assets/89498a06-d49c-4a74-9670-d7443e7984ab" />

| Compression ratio               | 0    | 0.1  | 0.25 | 0.5  | 0.6  | 0.7  | 0.8  | 0.9  |
|----------------------|------|------|------|------|------|------|------|------|
| Average Performance  | 95.7 | 95.5 | 95.5 | 95.5 | 95.5 | 95.3 | 94.9 | 90.5 |


</google-sheets-html-origin>

KVzip introduces compression overhead (2× prefilling time, with negligible memory overhead). The original KVzip repository also provides a version without compression overhead at the cost of performance, using DuoAttention-style head-level eviction.

I tried to make minimal changes to the original code, but I had to make some additions in pipeline.py. I follow the fake compression strategy from AdaKV in this repository, whereas the original [KVzip repository](https://github.com/snu-mllab/KVzip) provides optimized code that improves decoding speed by 2×.

Please review and let me know if there are any issues or if everything looks fine. Truly appreciate your great repository!


## Checklist

- Tests are working (`make test`)
- Code is formatted correctly (`make style`, on errors try fix with `make format`)
- Copyright header is included
- [x] All commits are signed-off  using `git commit -s`
- [x] (new press) `mypress_press.py` is in the `presses` directory
- [x] (new press) `MyPress` is in `__init__.py` 
- [x] (new press) `README.md` is updated with a 1 liner about the new press in the Available presses section
- [x] (new press) New press is in the `default_presses` list in `tests/default_presses.py`
- [x] (new press) A docstring is provided that follows the same structure as the existing ones
