### PR TITLE
run backbone model only for prefill

### DIFF
--- a/kvpress/pipeline.py
+++ b/kvpress/pipeline.py
@@ -195,6 +195,7 @@ class KVPressTextGenerationPipeline(Pipeline):
             cache = DynamicCache()
 
         with press(self.model) if press is not None else contextlib.nullcontext():
+            # We run the model without the lm head for pre-filling.
             self.model.model(
                 input_ids=context_ids,
                 past_key_values=cache,

--- a/kvpress/pipeline.py
+++ b/kvpress/pipeline.py
@@ -195,11 +195,10 @@ class KVPressTextGenerationPipeline(Pipeline):
             cache = DynamicCache()
 
         with press(self.model) if press is not None else contextlib.nullcontext():
-            self.model(
+            self.model.model(
                 input_ids=context_ids,
                 past_key_values=cache,
                 output_attentions=self.output_attentions(press),
-                num_logits_to_keep=1,
             )
 
         logger.debug(f"Context Length: {context_length}")


### PR DESCRIPTION
## PR description

Fixes #91 

## Results Llama-3.1-8B-Instruct on RULER-4k


Variant | Peak GPU Memory | Throughput
-- | -- | --
Original | 17.88 GB | 92 samples/sec
Modified | 16.95 GB | 96 samples/sec

While the savings is modest for the experiment I did, they can become significant in scenarios involving large models or long context sequences.

## Checklist

- Tests are working (`make test`)
- Code is formatted correctly (`make style`, on errors try fix with `make format`)
- Copyright header is included
- [x] All commits are signed-off  using `git commit -s`
- [ ] (new press) `mypress_press.py` is in the `presses` directory
- [ ] (new press) `MyPress` is in `__init__.py` 
- [ ] (new press) `README.md` is updated with a 1 liner about the new press in the Available presses section
- [ ] (new press) New press is in the `default_presses` list in `tests/default_presses.py`
- [ ] (new press) A docstring is provided that follows the same structure as the existing ones
