### PR TITLE
Fix links in benchmarks directory

### DIFF
--- a/evaluation/benchmarks/README.md
+++ b/evaluation/benchmarks/README.md
@@ -17,7 +17,7 @@ Please refer to the README of each dataset for more information on how the Huggi
 
 Average performance the 13 tasks of the RULER dataset with 4k context length (per task results [here](../evaluation/assets/)):
 
-![RULER](../evaluation/assets/ruler_4096_average%20score.png) 
+![RULER](../../evaluation/assets/ruler_4096_average%20score.png) 
 
 Observations: 
 - snapkv w/ question consistently outperforms other methods. However this method can't be use for use cases such as prompt caching as it requires the question to be known beforehand.
@@ -35,14 +35,14 @@ Observations:
 </summary>
 
 Shortdep_qa
-![shortdep_qa](../evaluation/assets/loogle_shortdep_qa.png)
+![shortdep_qa](../../evaluation/assets/loogle_shortdep_qa.png)
 Shortdep_cloze
-![shortdep_cloze](../evaluation/assets/loogle_shortdep_cloze.png)
+![shortdep_cloze](../../evaluation/assets/loogle_shortdep_cloze.png)
 Longdep_qa
-![longdep_qa](../evaluation/assets/loogle_longdep_qa.png) 
+![longdep_qa](../../evaluation/assets/loogle_longdep_qa.png) 
 
 Observations: 
-- Metrics are adapted from loogle benchmark, see [here](../evaluation/loogle/calculate_metrics.py). The plot show the average score (mean over all submetrics) for each task.
+- Metrics are adapted from loogle benchmark, see [here](../../evaluation/loogle/calculate_metrics.py). The plot show the average score (mean over all submetrics) for each task.
 - The metrics are not always correlated with the quality of the answer, especially for longdep_qa task. LLM-as-a-judge may better suited for a more refined evaluation.
 - Again, snapkv w/ question consistently outperforms other methods.
 - In longdep_qa, the model looses track on counting (e.g. answer to "How many times is person x mentioned?" gets lower with increased compression ratio). This is not necessarily reflected in the metrics.
@@ -60,13 +60,13 @@ Observations:
 </summary>
 
 kv_retrieval
-![kv_retrieval](../evaluation/assets/infinitebench_kv_retrieval.png)
+![kv_retrieval](../../evaluation/assets/infinitebench_kv_retrieval.png)
 longbook_choice_eng
-![longbook_choice_eng](../evaluation/assets/infinitebench_longbook_choice_eng.png)
+![longbook_choice_eng](../../evaluation/assets/infinitebench_longbook_choice_eng.png)
 longbook_qa_eng
-![longbook_qa_eng](../evaluation/assets/infinitebench_longbook_qa_eng.png)
+![longbook_qa_eng](../../evaluation/assets/infinitebench_longbook_qa_eng.png)
 longdialogue_qa_eng
-![longdialogue_qa_eng](../evaluation/assets/infinitebench_longdialogue_qa_eng.png)
+![longdialogue_qa_eng](../../evaluation/assets/infinitebench_longdialogue_qa_eng.png)
 
 
 Observations: 


### PR DESCRIPTION
## PR description

Quick PR to fix links for benchmarks

## Checklist

- Tests are working (`make test`)
- Code is formatted correctly (`make style`, on errors try fix with `make format`)
- Copyright header is included
- [x] All commits are signed-off  using `git commit -s`
- [ ] (new press) `mypress_press.py` is in the `presses` directory
- [ ] (new press) `MyPress` is in `__init__.py` 
- [ ] (new press) `README.md` is updated with a 1 liner about the new press in the Available presses section
- [ ] (new press) New press is in the `default_presses` list in `tests/default_presses.py`
- [ ] (new press) A docstring is provided that follows the same structure as the existing ones
