### PR TITLE
Fix cache sequence tracking after generation

### DIFF
--- a/kvpress/pipeline.py
+++ b/kvpress/pipeline.py
@@ -312,6 +312,8 @@ class KVPressTextGenerationPipeline(Pipeline):
                 for layer_idx, sequence_length in enumerate(cache_seq_lengths)
             ]
 
+        cache._seen_tokens = cache_seq_lengths[0]
+
         return answer
 
 


### PR DESCRIPTION
Changes:
- Reset the cache’s `_seen_tokens` value after removing generated tokens within the pipeline’s `generate_answer` method to maintain cache invariance.
- Added checks ensuring the past key/value cache’s sequence length and seen token count remain unchanged after generating an answer.
- Implemented a new test verifying invariance for quantized caches.