### PR TITLE
Upgrade expected attention with support for more models

### DIFF
--- a/kvpress/presses/expected_attention_press.py
+++ b/kvpress/presses/expected_attention_press.py
@@ -67,45 +67,46 @@ class ExpectedAttentionPress(ScorerPress):
         """
 
         bsz, q_len, _ = hidden_states.shape
-        n, d = module.config.num_attention_heads, module.head_dim
+        num_heads, head_dim = module.config.num_attention_heads, module.head_dim
 
         # Remove first hidden_states that likely contain outliers
         h = hidden_states[:, self.n_sink :]
 
-        if isinstance(module, (Qwen3Attention, Gemma3Attention)):
-            # Qwen and Gemma use QK norm, which is not compatible with ExpectedAttentionPress (for now)
-            raise NotImplementedError(f"ExpectedAttentionPress not yet implemented for {module.__class__}.")
-        elif isinstance(module, Phi3Attention):
-            Wq = module.qkv_proj.weight[: n * d]
+        if isinstance(module, Phi3Attention):
+            qkv = module.qkv_proj(h)
+            query_states = qkv[..., : num_heads * head_dim]
         elif hasattr(module, "q_proj"):
             # Assume Llama-like attention layer
-            Wq = module.q_proj.weight  # type: ignore[assignment]
+            query_states = module.q_proj(h)
         else:
             raise NotImplementedError(f"ExpectedAttentionPress not yet implemented for {module.__class__}.")
 
-        # Query mean
-        mean_h = torch.mean(h, dim=1, keepdim=True)
-        mu = torch.matmul(mean_h, Wq.T).squeeze(1)
-        mu = mu.view(bsz, n, d)
+        query_states = query_states.view(bsz, h.shape[1], num_heads, head_dim).transpose(1, 2)
+
+        # Support for Qwen3 and Gemma3 QK norm
+        if isinstance(module, (Qwen3Attention, Gemma3Attention)):
+            query_states = module.q_norm(query_states)
+
+        mu = query_states.mean(dim=2, keepdim=True)
 
         # Query covariance
         cov = None
         if self.use_covariance:
-            h = h - mean_h
-            q = torch.matmul(h, Wq.T).view(bsz, h.shape[1], n, d)
-            # Compute per-head query covariance directly in the projected space.
-            # This avoids forming an intermediate O((n * d)^2) covariance matrix
-            # for the full hidden states, reducing both memory and compute cost.
-            cov = torch.einsum("bsni,bsnj->bnij", q, q) / h.shape[1]
+            centered_states = query_states - mu
+            centered_states = centered_states.transpose(1, 2)
+            cov = torch.einsum("bsni,bsnj->bnij", centered_states, centered_states) / h.shape[1]
+        mu = mu.squeeze(2)
 
         # RoPE rotation matrix on next n_future_positions
         position_ids = torch.arange(q_len, q_len + self.n_future_positions).unsqueeze(0).to(mu.device)
         cos, sin = module.rotary_emb(mu, position_ids)
         cos, sin = cos[0], sin[0]
 
-        Id = torch.eye(d, device=cos.device, dtype=cos.dtype)
-        P = torch.zeros((d, d), device=cos.device, dtype=cos.dtype)
-        P[d // 2 :, : d // 2], P[: d // 2, d // 2 :] = torch.eye(d // 2), -torch.eye(d // 2)
+        Id = torch.eye(head_dim, device=cos.device, dtype=cos.dtype)
+        P = torch.zeros((head_dim, head_dim), device=cos.device, dtype=cos.dtype)
+        P[head_dim // 2 :, : head_dim // 2], P[: head_dim // 2, head_dim // 2 :] = torch.eye(head_dim // 2), -torch.eye(
+            head_dim // 2
+        )
         R = cos.unsqueeze(1) * Id + sin.unsqueeze(1) * P
 
         # Apply average rotation to the mean and covariance


### PR DESCRIPTION
## PR description

Right now expected attention does not support QK norm models (Gemma, Qwen). This PR:
-  changes EA code slightly to support them, by computing mean and covariance in query states.
- makes the code of EA more standard wrt to other presses (naming conventions for Q layers and tensor dimensions)


To make sure the two methods are equivalent, I tested them with Llama 3.1-8B on Ruler 4096 with 0.5 compression, obtaining the same results with a delta < .5%, probably due to precision.

Also, I benchmarked the compression speed across 10 runs to make sure working in the query space does not slow down compression. Turns out it does not, here are the results:

Current implementation
```
Use covariance: True
   Seq len |    Time (ms) |   Std (ms)
--------------------------------------
       500 |      62.2459 |     2.1639
      1024 |      71.5522 |     1.0194
      2048 |     102.9493 |     1.1546
      4096 |     180.9449 |     1.4609
      8192 |     357.3696 |     1.9820
Use covariance: False
   Seq len |    Time (ms) |   Std (ms)
--------------------------------------
       500 |      63.4290 |     1.9213
      1024 |      73.5406 |     2.2720
      2048 |     102.5547 |     0.6407
      4096 |     180.7852 |     1.6742
      8192 |     357.9888 |     1.6556
```

New implementation
```
Use covariance: True
   Seq len |    Time (ms) |   Std (ms)
--------------------------------------
       500 |      60.9933 |     2.7061
      1024 |      70.5250 |     0.6948
      2048 |     102.1577 |     1.0129
      4096 |     179.3266 |     1.1186
      8192 |     357.6134 |     1.7375
Use covariance: False
   Seq len |    Time (ms) |   Std (ms)
--------------------------------------
       500 |      60.7389 |     1.8204
      1024 |      70.3875 |     0.5291
      2048 |     101.0313 |     0.7018
      4096 |     180.4022 |     1.1061
      8192 |     357.9737 |     0.9381

```


## Checklist

- Tests are working (`make test`)
- Code is formatted correctly (`make style`, on errors try fix with `make format`)
- Copyright header is included
- [x] All commits are signed-off  using `git commit -s`
- [ ] (new press) `mypress_press.py` is in the `presses` directory
- [ ] (new press) `MyPress` is in `__init__.py` 
- [ ] (new press) `README.md` is updated with a 1 liner about the new press in the Available presses section
- [ ] (new press) New press is in the `default_presses` list in `tests/default_presses.py`
- [ ] (new press) A docstring is provided that follows the same structure as the existing ones
