### PR TITLE
Move tests to GPU

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,8 @@ Description of your PR. Fixes # (issue) (if applicable)
 
 ## Checklist
 
+Before submitting a PR, please make sure:
+
 - Tests are working (`make test`)
 - Code is formatted correctly (`make style`, on errors try fix with `make format`)
 - Copyright header is included

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,10 +6,11 @@ Description of your PR. Fixes # (issue) (if applicable)
 
 Before submitting a PR, please make sure:
 
-- Tests are working (`make test`)
-- Code is formatted correctly (`make style`, on errors try fix with `make format`)
-- Copyright header is included
+- [ ] Tests are working (`make test`)
+- [ ] Code is formatted correctly (`make style`, on errors try fix with `make format`)
+- [ ] Copyright header is included
 - [ ] All commits are signed-off  using `git commit -s`
+
 - [ ] (new press) `mypress_press.py` is in the `presses` directory
 - [ ] (new press) `MyPress` is in `__init__.py` 
 - [ ] (new press) `README.md` is updated with a 1 liner about the new press in the Available presses section

--- a/Makefile
+++ b/Makefile
@@ -42,10 +42,16 @@ reports:
 .PHONY: test
 test: reports
 	$(UV) add optimum-quanto
-	$(UV) add flash-attn --no-build-isolation
+	$(UV) add flash-attn
 	PYTHONPATH=. \
 	$(UV) run pytest \
 		--cov-report xml:reports/coverage.xml \
 		--cov=kvpress/ \
 		--junitxml=./reports/junit.xml \
-		tests/
+		-v \
+		tests/ | tee reports/pytest_output.log
+	@if grep -q "SKIPPED" reports/pytest_output.log; then \
+		echo "Error: Tests were skipped. All tests must run."; \
+		grep "SKIPPED" reports/pytest_output.log; \
+		exit 1; \
+	fi

--- a/Makefile
+++ b/Makefile
@@ -41,8 +41,8 @@ reports:
 
 .PHONY: test
 test: reports
-	$(UV) add optimum-quanto
-	$(UV) add flash-attn
+	$(UV) pip install optimum-quanto
+	$(UV) pip install flash-attn
 	PYTHONPATH=. \
 	$(UV) run pytest \
 		--cov-report xml:reports/coverage.xml \

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,8 @@ reports:
 
 .PHONY: test
 test: reports
+	$(UV) add optimum-quanto
+	$(UV) add flash-attn --no-build-isolation
 	PYTHONPATH=. \
 	$(UV) run pytest \
 		--cov-report xml:reports/coverage.xml \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,9 +22,6 @@ dependencies = [
     "accelerate>=1.0.0,<2",
     "requests>=2.32.3,<3",
     "cachetools>=5.5.2,<6",
-    "optimum-quanto>=0.2.7",
-    "hatch>=1.14.1",
-    "flash-attn>=2.8.2",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,9 @@ dependencies = [
     "accelerate>=1.0.0,<2",
     "requests>=2.32.3,<3",
     "cachetools>=5.5.2,<6",
+    "optimum-quanto>=0.2.7",
+    "hatch>=1.14.1",
+    "flash-attn>=2.8.2",
 ]
 
 [project.optional-dependencies]

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -7,21 +7,29 @@ import torch
 from transformers import AutoModelForCausalLM, pipeline
 
 
+def get_device():
+    """Helper function that returns the appropriate device (GPU if available, otherwise CPU)"""
+    return "cuda:0" if torch.cuda.is_available() else "cpu"
+
+
 @pytest.fixture(scope="session")
 def unit_test_model():
-    return AutoModelForCausalLM.from_pretrained("MaxJeblick/llama2-0b-unit-test").eval()
+    model = AutoModelForCausalLM.from_pretrained("MaxJeblick/llama2-0b-unit-test").eval()
+    return model.to(get_device())
 
 
 @pytest.fixture(scope="session")
 def unit_test_model_output_attention():
-    return AutoModelForCausalLM.from_pretrained(
+    model = AutoModelForCausalLM.from_pretrained(
         "MaxJeblick/llama2-0b-unit-test", attn_implementation="eager", output_attentions=True
     ).eval()
+    return model.to(get_device())
 
 
 @pytest.fixture(scope="session")
 def danube_500m_model():
-    return AutoModelForCausalLM.from_pretrained("h2oai/h2o-danube3-500m-chat").eval()
+    model = AutoModelForCausalLM.from_pretrained("h2oai/h2o-danube3-500m-chat").eval()
+    return model.to(get_device())
 
 
 @pytest.fixture(scope="session")
@@ -29,7 +37,7 @@ def kv_press_unit_test_pipeline():
     return pipeline(
         "kv-press-text-generation",
         model="maxjeblick/llama2-0b-unit-test",
-        device=0 if torch.cuda.is_available() else -1,
+        device=get_device(),
     )
 
 
@@ -38,8 +46,29 @@ def kv_press_danube_pipeline():
     return pipeline(
         "kv-press-text-generation",
         model="h2oai/h2o-danube3-500m-chat",
-        device=0 if torch.cuda.is_available() else -1,
+        device=get_device(),
     )
+
+
+@pytest.fixture(scope="session")
+def kv_press_adaptive_pipeline():
+    """Flexible pipeline that uses GPU+flash attention if available, otherwise CPU"""
+    device = get_device()
+    ckpt = "meta-llama/Llama-3.2-1B-Instruct"
+
+    # Use flash attention only if GPU is available
+    model_kwargs = {}
+    if torch.cuda.is_available():
+        model_kwargs["attn_implementation"] = "flash_attention_2"
+
+    pipe = pipeline(
+        "kv-press-text-generation",
+        model=ckpt,
+        device=device,
+        torch_dtype="auto",
+        model_kwargs=model_kwargs,
+    )
+    return pipe
 
 
 @pytest.fixture(scope="session")

--- a/tests/integration/test_ruler.py
+++ b/tests/integration/test_ruler.py
@@ -27,12 +27,12 @@ def test_ruler_is_correct(kv_press_llama3_1_flash_attn_pipeline, df_ruler, press
     kwargs = press_dict["kwargs"][0]
     press = cls(**kwargs)
     if not hasattr(cls, "compression_ratio"):
-        pytest.skip(reason="Press does not support compression_ratio")
+        return  # "Press does not support compression_ratio"
     # set compression ratio to a small value for testing
     try:
         press.compression_ratio = 0.1
     except AttributeError:
-        pytest.skip(reason="Press does not support setting compression_ratio")
+        return  # "Press does not support setting compression_ratio"
 
     if cache == "dynamic":
         cache = DynamicCache()

--- a/tests/presses/test_block_press.py
+++ b/tests/presses/test_block_press.py
@@ -33,7 +33,7 @@ def test_block_press_is_streaming_top_k(unit_test_model):  # noqa: F811
     """
     press = HiddenStatesPress(compression_ratio=0.5)
     generator = torch.Generator().manual_seed(0)
-    input_ids = torch.randint(0, 1024, (1, 256), generator=generator)
+    input_ids = torch.randint(0, 1024, (1, 256), generator=generator).to(unit_test_model.device)
     keys_hash = []
     values_hash = []
 

--- a/tests/presses/test_finch_press.py
+++ b/tests/presses/test_finch_press.py
@@ -16,6 +16,6 @@ def test_finch_press(unit_test_model):  # noqa: F811
     ]:
         press.delimiter_token_id = unit_test_model.config.eos_token_id
         with press(unit_test_model):
-            input_ids = torch.arange(10, 20)
+            input_ids = torch.arange(10, 20).to(unit_test_model.device)
             input_ids[8] = press.delimiter_token_id
             unit_test_model(input_ids.unsqueeze(0))

--- a/tests/presses/test_head_compression.py
+++ b/tests/presses/test_head_compression.py
@@ -28,7 +28,7 @@ def test_wrapper_head_compression(unit_test_model, wrapper_press, compression_ra
     p = KnormPress(compression_ratio=compression_ratio)
     press = wrapper_press(press=p)
     with press(unit_test_model):
-        input_ids = torch.randint(0, 1024, (1, 128))
+        input_ids = torch.randint(0, 1024, (1, 128)).to(unit_test_model.device)
         unit_test_model(input_ids, past_key_values=DynamicCache()).past_key_values
 
     assert unit_test_model.model.layers[0].self_attn.masked_key_indices is not None
@@ -47,7 +47,7 @@ def test_wrapper_head_compression(unit_test_model, wrapper_press, compression_ra
 def test_head_compression(unit_test_model, press, compression_ratio, layerwise):  # noqa: F811
     press = KVzipPress(compression_ratio=compression_ratio, layerwise=layerwise)
     with press(unit_test_model):
-        input_ids = torch.randint(0, 1024, (1, 128))
+        input_ids = torch.randint(0, 1024, (1, 128)).to(unit_test_model.device)
         unit_test_model(input_ids, past_key_values=DynamicCache()).past_key_values
 
     assert unit_test_model.model.layers[0].self_attn.masked_key_indices is not None

--- a/tests/presses/test_observed_attention_press.py
+++ b/tests/presses/test_observed_attention_press.py
@@ -13,18 +13,18 @@ from tests.fixtures import unit_test_model, unit_test_model_output_attention  # 
 
 @torch.no_grad()
 def test_observed_drops_attention_output(unit_test_model, unit_test_model_output_attention, caplog):  # noqa: F811
-    input_ids = unit_test_model.dummy_inputs["input_ids"]
+    input_ids = unit_test_model.dummy_inputs["input_ids"].to(unit_test_model.device)
     output = unit_test_model(input_ids, past_key_values=DynamicCache())
     assert output.attentions is None
 
-    input_ids = unit_test_model_output_attention.dummy_inputs["input_ids"]
+    input_ids = unit_test_model_output_attention.dummy_inputs["input_ids"].to(unit_test_model.device)
     attentions = unit_test_model_output_attention(input_ids, past_key_values=DynamicCache()).attentions
     assert all([isinstance(attention, torch.Tensor) for attention in attentions])
 
     with caplog.at_level(logging.DEBUG):
         press = ObservedAttentionPress(compression_ratio=0.4)
         with press(unit_test_model_output_attention):
-            input_ids = unit_test_model_output_attention.dummy_inputs["input_ids"]
+            input_ids = unit_test_model_output_attention.dummy_inputs["input_ids"].to(unit_test_model.device)
             output = unit_test_model_output_attention(input_ids, past_key_values=DynamicCache())
 
             # There's a slight mismatch in outputs when using a model that has output_attentions=True
@@ -36,7 +36,7 @@ def test_observed_drops_attention_output(unit_test_model, unit_test_model_output
 
     press = ObservedAttentionPress(compression_ratio=0.4, output_attentions=True)
     with press(unit_test_model_output_attention):
-        input_ids = unit_test_model_output_attention.dummy_inputs["input_ids"]
+        input_ids = unit_test_model_output_attention.dummy_inputs["input_ids"].to(unit_test_model.device)
         output = unit_test_model_output_attention(input_ids, past_key_values=DynamicCache())
 
         assert all(

--- a/tests/presses/test_presses.py
+++ b/tests/presses/test_presses.py
@@ -31,7 +31,7 @@ def test_composed_press(unit_test_model):  # noqa: F811
     press2 = ThinKPress(key_channel_compression_ratio=0.5, window_size=2)
     composed_press = ComposedPress([press1, press2])
     with composed_press(unit_test_model):
-        input_ids = unit_test_model.dummy_inputs["input_ids"]
+        input_ids = unit_test_model.dummy_inputs["input_ids"].to(unit_test_model.device)
         unit_test_model(input_ids, past_key_values=DynamicCache()).past_key_values
 
 
@@ -40,7 +40,7 @@ def test_chunk_press(unit_test_model):  # noqa: F811
     for chunk_length in [2, 4, 8, 128]:
         composed_press = ChunkPress(press=press, chunk_length=chunk_length)
         with composed_press(unit_test_model):
-            input_ids = torch.randint(0, 1024, (1, 256))
+            input_ids = torch.randint(0, 1024, (1, 256), device=unit_test_model.device)
             cache = DynamicCache()
             unit_test_model(input_ids, past_key_values=cache).past_key_values
             assert cache.get_seq_length() == 128
@@ -51,7 +51,7 @@ def test_chunkkv_press(unit_test_model):  # noqa: F811
     for chunk_length in [2, 4, 8, 128]:
         composed_press = ChunkKVPress(press=press, chunk_length=chunk_length)
         with composed_press(unit_test_model):
-            input_ids = torch.randint(0, 1024, (1, 256))
+            input_ids = torch.randint(0, 1024, (1, 256), device=unit_test_model.device)
             cache = DynamicCache()
             unit_test_model(input_ids, past_key_values=cache).past_key_values
             assert cache.get_seq_length() == 128
@@ -84,7 +84,7 @@ def test_presses_run(unit_test_model, press_dict, wrapper_press):  # noqa: F811
         if hasattr(press, "__post_init_from_model__"):
             press.__post_init_from_model__(unit_test_model)
         with press(unit_test_model):
-            input_ids = torch.randint(0, 1024, (1, 128))
+            input_ids = torch.randint(0, 1024, (1, 128), device=unit_test_model.device)
             unit_test_model(input_ids, past_key_values=DynamicCache()).past_key_values
         # Check that the press has a compression_ratio attribute
         assert hasattr(press, "compression_ratio")
@@ -95,7 +95,9 @@ def test_presses_run_observed_attention(unit_test_model_output_attention):  # no
         for compresion_ratio in [0.2, 0.8]:
             press = cls(compression_ratio=compresion_ratio)
             with press(unit_test_model_output_attention):
-                input_ids = unit_test_model_output_attention.dummy_inputs["input_ids"]
+                input_ids = unit_test_model_output_attention.dummy_inputs["input_ids"].to(
+                    unit_test_model_output_attention.device
+                )
                 unit_test_model_output_attention(input_ids, past_key_values=DynamicCache()).past_key_values
 
 
@@ -126,7 +128,7 @@ def test_presses_keep_highest_score(unit_test_model):  # noqa: F811
     for compresion_ratio in [0.0, 0.2, 0.4, 0.6, 0.8]:
         press = StoreKnormPress(compression_ratio=compresion_ratio)
         with press(unit_test_model):
-            input_ids = torch.randint(0, 3_000, (5, 256))
+            input_ids = torch.randint(0, 3_000, (5, 256), device=unit_test_model.device)
             past_key_values = unit_test_model(input_ids, past_key_values=DynamicCache()).past_key_values
 
         for scores, key in zip(press.scores, past_key_values.key_cache):

--- a/tests/presses/test_wrappers.py
+++ b/tests/presses/test_wrappers.py
@@ -14,7 +14,7 @@ def test_composed_press_qfilter_without_post_init(unit_test_model):  # noqa: F81
     composed_press = ComposedPress([press1, press2])
     with pytest.raises(ValueError, match="post_init_from_model"):
         with composed_press(unit_test_model):
-            input_ids = unit_test_model.dummy_inputs["input_ids"]
+            input_ids = unit_test_model.dummy_inputs["input_ids"].to(unit_test_model.device)
             unit_test_model(input_ids, past_key_values=DynamicCache()).past_key_values
 
 
@@ -28,7 +28,7 @@ def test_composed_press_duo_attention_without_post_init(unit_test_model):  # noq
     composed_press = ComposedPress([press1, press2])
     with pytest.raises(ValueError, match="post_init_from_model"):
         with composed_press(unit_test_model):
-            input_ids = unit_test_model.dummy_inputs["input_ids"]
+            input_ids = unit_test_model.dummy_inputs["input_ids"].to(unit_test_model.device)
             unit_test_model(input_ids, past_key_values=DynamicCache()).past_key_values
 
 
@@ -45,7 +45,7 @@ def test_composed_qfilter_press_with_post_init(unit_test_model):  # noqa: F811
 
     composed_press = ComposedPress([press1, press2])
     with composed_press(unit_test_model):
-        input_ids = unit_test_model.dummy_inputs["input_ids"]
+        input_ids = unit_test_model.dummy_inputs["input_ids"].to(unit_test_model.device)
         with pytest.raises(RuntimeError, match="The size of tensor"):
             unit_test_model(input_ids, past_key_values=DynamicCache()).past_key_values
 
@@ -63,5 +63,5 @@ def test_composed_duo_attention_press_with_post_init(unit_test_model):  # noqa: 
 
     composed_press = ComposedPress([press1, press2])
     with composed_press(unit_test_model):
-        input_ids = unit_test_model.dummy_inputs["input_ids"]
+        input_ids = unit_test_model.dummy_inputs["input_ids"].to(unit_test_model.device)
         unit_test_model(input_ids, past_key_values=DynamicCache()).past_key_values

--- a/tests/test_attention_patch.py
+++ b/tests/test_attention_patch.py
@@ -7,7 +7,8 @@ from kvpress.attention_patch import search_hyperplane
 
 
 def test_search_hyperplane():
+    device = "cuda:0" if torch.cuda.is_available() else "cpu"
     bsz, seq_len, head_dim = 50, 500, 128
-    X = torch.rand(bsz, seq_len, head_dim)
+    X = torch.rand(bsz, seq_len, head_dim, device=device)
     Y = search_hyperplane(X)
     assert torch.exp(torch.bmm(X, Y.unsqueeze(-1))).max() == 0

--- a/tests/test_per_layer_compression_press.py
+++ b/tests/test_per_layer_compression_press.py
@@ -13,7 +13,7 @@ from tests.fixtures import unit_test_model  # noqa: F401
 def test_per_layer_compression_press(unit_test_model):  # noqa: F811
     press = PerLayerCompressionPress(compression_ratios=[0.1, 1], press=KnormPress())
     with press(unit_test_model):
-        input_ids = torch.randint(0, 3_000, (5, 256))
+        input_ids = torch.randint(0, 3_000, (5, 256), device=unit_test_model.device)
         past_key_values = unit_test_model(input_ids, past_key_values=DynamicCache()).past_key_values
 
     assert past_key_values.key_cache[0].shape == torch.Size([5, 2, 230, 6])

--- a/tests/test_press_call.py
+++ b/tests/test_press_call.py
@@ -23,7 +23,7 @@ def test_context_manager_applies_compression(unit_test_model):  # noqa: F811
     press = KnormPress(compression_ratio=0.2)
 
     with press(unit_test_model):
-        input_ids = unit_test_model.dummy_inputs["input_ids"]
+        input_ids = unit_test_model.dummy_inputs["input_ids"].to(unit_test_model.device)
         past_key_values = unit_test_model(input_ids, past_key_values=DynamicCache()).past_key_values
 
     seq_len = input_ids.shape[-1]
@@ -32,6 +32,7 @@ def test_context_manager_applies_compression(unit_test_model):  # noqa: F811
         assert key.shape[2] == int(seq_len * 0.8) == past_key_values.get_seq_length()
         assert values.shape[2] == int(seq_len * 0.8) == past_key_values.get_seq_length()
 
+    input_ids = unit_test_model.dummy_inputs["input_ids"].to(unit_test_model.device)
     past_key_values = unit_test_model(input_ids, past_key_values=DynamicCache()).past_key_values
 
     for key, values in past_key_values:


### PR DESCRIPTION
## PR description

This PR

- moves existing tests to gpu (if run on a GPU)
- `make test` will only pass if all tests pass (i.e. we do not allow to skip tests)

Fixes #131 

## Checklist

- Tests are working (`make test`)
- Code is formatted correctly (`make style`, on errors try fix with `make format`)
- Copyright header is included
- [ ] All commits are signed-off  using `git commit -s`
- [ ] (new press) `mypress_press.py` is in the `presses` directory
- [ ] (new press) `MyPress` is in `__init__.py` 
- [ ] (new press) `README.md` is updated with a 1 liner about the new press in the Available presses section
- [ ] (new press) New press is in the `default_presses` list in `tests/default_presses.py`
- [ ] (new press) A docstring is provided that follows the same structure as the existing ones
