### PR TITLE
Fix ComposedPress

### DIFF
--- a/kvpress/presses/composed_press.py
+++ b/kvpress/presses/composed_press.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 from kvpress.presses.adakv_press import AdaKVPress
 from kvpress.presses.base_press import BasePress
 from kvpress.presses.kvzip_press import KVzipPress
-from kvpress.presses.observed_attention_press import ObservedAttentionPress
 
 
 @dataclass


### PR DESCRIPTION
Fix issues #145  and #146 

I also added a section in the docstring:

```
    ⚠️ ComposedPress may fail if a press depends on features beyond keys and values
    (e.g., hidden states or attention weights). For example, combining KnormPress
    with ObservedAttentionPress fails because KnormPress prunes keys and values,
    but ObservedAttentionPress then receives the original attention weights.
```


cc @JhaceLam 