### PR TITLE
Fix kvzip having poor performance

### DIFF
--- a/kvpress/presses/kvzip_press.py
+++ b/kvpress/presses/kvzip_press.py
@@ -116,10 +116,7 @@ class KVzipPress(BasePress):
 
         def wrapped_forward(model_self, *args, **kwargs):
             self._context_ids = kwargs["input_ids"]
-            assert (
-                "past_key_value" in kwargs or "past_key_values" in kwargs
-            ), f"KVzipPress requires 'past_key_value' or 'past_key_values' during prefilling. Got {kwargs.keys()}"
-            self._cache = kwargs.get("past_key_values", None) or kwargs.get("past_key_value", None)
+            self._cache = kwargs["past_key_values"]
             return original_forward(*args, **kwargs)
 
         model.model.forward = MethodType(wrapped_forward, model.model)


### PR DESCRIPTION
## PR description

Probable fix of #147.

**Root cause of the issue:**
- `kwargs.get("past_key_values", None)` returns `DynamicCache(layers=[])`
- `bool(DynamicCache(layers=[]))` equals to false, as bool method falls back to `__len__` and `len(DynamicCache(layers=[])) == len([]) = 0`.
- Thus, `self._cache=None`, and it won't be used to perform kvzip compression.

**Cause of this bug:**
Transformers library 4.54. changed the naming convention from `past_key_value` to `past_key_values`.
During some transition period, however, there existed some back on forth on the naming convention ( transformers changed cache implementation a few times, see e.g .https://github.com/NVIDIA/kvpress/pull/104). I decided to make kvzip compatible with both naming conventions while working on https://github.com/NVIDIA/kvpress/pull/115 to allow for smoother devleopment. As it turned out, my implementation was faulty.

**Comments:**
There are other parts in kvzip that can be refactored. For this PR, I'll only address the actual bug fix to have better visibility.


## Checklist

Before submitting a PR, please make sure:

- [X] Tests are working (`make test`)
- [X] Code is formatted correctly (`make style`, on errors try fix with `make format`)
- [X] Copyright header is included
- [X] All commits are signed-off  using `git commit -s`
