### PR TITLE
add exception handling in ScorerPress

### DIFF
--- a/kvpress/presses/scorer_press.py
+++ b/kvpress/presses/scorer_press.py
@@ -8,8 +8,8 @@ from dataclasses import dataclass
 import torch
 from torch import nn
 
-from kvpress.presses.utils import KVPressNonFatalError
 from kvpress.presses.base_press import BasePress
+from kvpress.presses.utils import KVPressNonFatalError
 
 logger = logging.getLogger(__name__)
 

--- a/kvpress/presses/snapkv_press.py
+++ b/kvpress/presses/snapkv_press.py
@@ -82,7 +82,9 @@ class SnapKVPress(ScorerPress):
         num_key_value_groups = module.config.num_attention_heads // num_key_value_heads
 
         if not hidden_states.shape[1] > self.window_size:
-            raise SnapKVContextLengthError(f"Query length {hidden_states.shape[1]} should be greater than the window size {self.window_size}")
+            raise SnapKVContextLengthError(
+                f"Query length {hidden_states.shape[1]} should be greater than the window size {self.window_size}"
+            )
 
         if attentions is not None:
             attn_weights = attentions[..., -self.window_size :, : -self.window_size]

--- a/kvpress/presses/utils.py
+++ b/kvpress/presses/utils.py
@@ -8,14 +8,18 @@ from transformers.models.gemma3.modeling_gemma3 import Gemma3Attention
 from transformers.models.phi3.modeling_phi3 import Phi3Attention
 from transformers.models.qwen3.modeling_qwen3 import Qwen3Attention
 
+
 class KVPressNonFatalError(Exception):
     """Base exception class for non-fatal errors, these errors do not terminate the program."""
+
     pass
 
 
 class SnapKVContextLengthError(KVPressNonFatalError):
     """When context length is not valid in SnapKV."""
+
     pass
+
 
 def get_query_states(module: nn.Module, hidden_states: torch.Tensor) -> torch.Tensor:
     """


### PR DESCRIPTION
## PR description

In `ScorerPress`, when computing the score, it is not guaranteed to be success. In practice, I found `SnapKVPress` could have assertion error and terminate the program if the context length is shorter than the window length.

I think a more reasonable to add a try block here and return the KV unchanged if any error.

## Checklist

Before submitting a PR, please make sure:

- [x] Tests are working (`make test`)
- [x] Code is formatted correctly (`make style`, on errors try fix with `make format`)
- [x] Copyright header is included
- [x] All commits are signed-off  using `git commit -s`

- [x] (new press) `mypress_press.py` is in the `presses` directory
- [x] (new press) `MyPress` is in `__init__.py` 
- [x] (new press) `README.md` is updated with a 1 liner about the new press in the Available presses section
- [x] (new press) New press is in the `default_presses` list in `tests/default_presses.py`
- [x] (new press) A docstring is provided that follows the same structure as the existing ones
