### PR TITLE
Added support for the LFM2.5 model.

### DIFF
--- a/kvpress/pipeline.py
+++ b/kvpress/pipeline.py
@@ -214,7 +214,6 @@ class KVPressTextGenerationPipeline(Pipeline):
             else:
                 cache = DynamicCache()
 
-
         # We only perform prefill compression if the press is a prefill press
         perform_prefill_compression = press is not None and not isinstance(press, DecodingPress)
         with press(self.model) if perform_prefill_compression else contextlib.nullcontext():

--- a/kvpress/presses/base_press.py
+++ b/kvpress/presses/base_press.py
@@ -11,6 +11,7 @@ import torch
 from torch import nn
 from transformers import (
     Gemma3ForConditionalGeneration,
+    Lfm2ForCausalLM,
     LlamaForCausalLM,
     MistralForCausalLM,
     Phi3ForCausalLM,
@@ -18,9 +19,7 @@ from transformers import (
     QuantizedCache,
     Qwen2ForCausalLM,
     Qwen3ForCausalLM,
-    Lfm2ForCausalLM
 )
-
 from transformers.models.lfm2.modeling_lfm2 import Lfm2HybridConvCache
 
 from kvpress.utils import extract_keys_and_values
@@ -34,7 +33,7 @@ SUPPORTED_MODELS = (
     Qwen2ForCausalLM,
     Qwen3ForCausalLM,
     Gemma3ForConditionalGeneration,
-    Lfm2ForCausalLM
+    Lfm2ForCausalLM,
 )
 
 
@@ -139,7 +138,7 @@ class BasePress:
         cache = kwargs["past_key_values"]
 
         if isinstance(cache, Lfm2HybridConvCache):
-            cache_layer = None # TODO: implement for Lfm2
+            cache_layer = None  # TODO: implement for Lfm2
         else:
             cache_layer = cache.layers[module.layer_idx]
 
@@ -161,8 +160,8 @@ class BasePress:
             cache_layer.cumulative_length = keys.shape[2]
         else:
             if isinstance(cache, Lfm2HybridConvCache):
-                cache.key_cache[module.layer_idx] = keys
-                cache.value_cache[module.layer_idx] = values
+                cache.key_cache[module.layer_idx] = keys  # type: ignore[index]
+                cache.value_cache[module.layer_idx] = values  # type: ignore[index]
             else:
                 cache_layer.keys = keys
                 cache_layer.values = values
@@ -208,7 +207,8 @@ class BasePress:
                     # Skip layers with sliding window attention, only for Gemma3
                     continue
 
-                # for some models/layers, self_attn might be None (e.g., LFM's convolutional layers), so we check before registering the hook
+                # for some models/layers, self_attn might be None (e.g., LFM's convolutional layers),
+                # so we check before registering the hook
                 if not hasattr(layer, "self_attn") or layer.self_attn is None:
                     continue
 

--- a/kvpress/utils.py
+++ b/kvpress/utils.py
@@ -5,9 +5,9 @@ import torch
 from torch import nn
 from transformers import Cache, QuantizedCache
 from transformers.models.gemma3.modeling_gemma3 import Gemma3Attention
+from transformers.models.lfm2.modeling_lfm2 import Lfm2HybridConvCache
 from transformers.models.phi3.modeling_phi3 import Phi3Attention
 from transformers.models.qwen3.modeling_qwen3 import Qwen3Attention
-from transformers.models.lfm2.modeling_lfm2 import Lfm2HybridConvCache
 
 
 def get_prerope_query_states(module: nn.Module, hidden_states: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
## PR description

Added support for the Hybrid LFM2.5 model. Tested on `LiquidAI/LFM2.5-1.2B-Instruct`.

## Checklist

Before submitting a PR, please make sure:

- [?] Tests are working (`make test`) (cannot test since I don't have a CUDA device, tested on MacBook)
- [+] Code is formatted correctly (`make style`, on errors try fix with `make format`)
- [+] Copyright header is included
- [+] All commits are signed-off  using `git commit -s`

You may test with this code:
```python
from transformers import pipeline
from kvpress import ExpectedAttentionPress

model = "LiquidAI/LFM2.5-1.2B-Instruct"
pipe = pipeline("kv-press-text-generation", model=model, device_map="mps", dtype="auto")

context = "The capital of France is Paris. The capital of Germany is Berlin. The capital of Italy is Rome."
question = "What is the capital of Germany?"

messages = [
    {"role": "user", "content": context},
    {"role": "user", "content": question},
]

# apply chat template to the messages, do not tokenize yet since the press will need to modify the input_ids
messages = pipe.tokenizer.apply_chat_template(messages, tokenize=False)
print(messages)

press = ExpectedAttentionPress(compression_ratio=0.5)
answer = pipe(messages, press=press)
print()
print(answer)
```