### PR TITLE
Reset DecodingPress state when exiting context manager

### DIFF
--- a/kvpress/presses/decoding_press.py
+++ b/kvpress/presses/decoding_press.py
@@ -3,10 +3,12 @@
 
 import logging
 from collections import defaultdict
+from contextlib import contextmanager
 from dataclasses import dataclass
 
 import torch
 import torch.nn as nn
+from transformers import PreTrainedModel
 from transformers.cache_utils import QuantizedCache
 
 from kvpress.presses.adakv_press import AdaKVPress
@@ -178,6 +180,14 @@ class DecodingPress(BasePress):
         """Reset the decoding press state."""
         self.hidden_states_buffer = defaultdict(list)
         self.layer_step_counts = defaultdict(int)
+
+    @contextmanager
+    def __call__(self, model: PreTrainedModel):
+        try:
+            with super().__call__(model):
+                yield
+        finally:
+            self.reset()
 
     def _find_target_compression_ratio(self, q_len: int, target_tokens: int) -> float:
         """


### PR DESCRIPTION
## Summary

- `DecodingPress.layer_step_counts` and `hidden_states_buffer` were not being reset between successive uses of teh context manager. When the evaluation framework runs `DecodingPress` across multiple questions (e.g. aime25 with 30 questions), stale state from a previous question's decoding carried over to the next, causing inconsistent compression behaviour depending on input order.
- Overrides `__call__` on `DecodingPress` to call `self.reset()` when the context manager exits. This mirrors the pattern already recognised in `PrefillDecodingPress.__call__`, which resets its inner `decoding_press` in its `finally` block.

## Test plan

- [ ] Existing `test_decoding_compression.py` tests should continue to pass (they already reuse the same press object across calls)
- [ ] Verify that `test_decoding_press_equivalence` still produces identical results for standalone vs combined press
- [ ] Run an evaluation with `DecodingPress` on a multi-question benchmark (e.g. aime25) and confirm scores are now deterministic regardless of question order

Fixes #191