### PR TITLE
Fix: CriticalKVPress head_dim fallback for models without config.head_dim

### DIFF
--- a/kvpress/presses/criticalkv_press.py
+++ b/kvpress/presses/criticalkv_press.py
@@ -59,7 +59,8 @@ class CriticalKVPress(ScorerPress):
         bsz, num_key_value_heads, k_len, _ = values.shape
         num_key_value_groups = module.config.num_attention_heads // num_key_value_heads
         Wo = module.o_proj.weight.transpose(0, 1)
-        Wo = Wo.view(module.config.num_attention_heads, module.config.head_dim, module.config.hidden_size)
+        head_dim = getattr(module.config, "head_dim", None) or (module.config.hidden_size // module.config.num_attention_heads)
+        Wo = Wo.view(module.config.num_attention_heads, head_dim, module.config.hidden_size)
         V = repeat_kv(values, num_key_value_groups)
 
         # We use head-wise computation instead of direct matmul to reduce the memory usage of WoV.

--- a/tests/presses/test_criticalkv_head_dim.py
+++ b/tests/presses/test_criticalkv_head_dim.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Regression test for CriticalKVPress head_dim fallback.
+
+Models like Qwen2 do not expose `config.head_dim` as an explicit attribute.
+Without the fallback to `hidden_size // num_attention_heads`, CriticalKVPress
+raises AttributeError in `vwl1norm`.
+"""
+
+import pytest
+import torch
+from transformers import DynamicCache
+
+from kvpress import CriticalAdaKVPress, CriticalKVPress, KnormPress
+from tests.fixtures import unit_test_model  # noqa: F401
+
+
+@pytest.fixture
+def model_without_head_dim(unit_test_model):  # noqa: F811
+    """Return the unit-test model with config.head_dim deleted to simulate Qwen2-like configs."""
+    config = unit_test_model.config
+    original = getattr(config, "head_dim", None)
+    if hasattr(config, "head_dim"):
+        delattr(config, "head_dim")
+    yield unit_test_model
+    # Restore
+    if original is not None:
+        config.head_dim = original
+
+
+def test_criticalkv_without_head_dim(model_without_head_dim):
+    """CriticalKVPress must work when config.head_dim is absent."""
+    assert not hasattr(model_without_head_dim.config, "head_dim")
+    press = CriticalKVPress(press=KnormPress(compression_ratio=0.5))
+    with press(model_without_head_dim):
+        input_ids = torch.randint(0, 1024, (1, 128), device=model_without_head_dim.device)
+        model_without_head_dim(input_ids, past_key_values=DynamicCache()).past_key_values
+
+
+def test_criticaladakv_without_head_dim(model_without_head_dim):
+    """CriticalAdaKVPress must work when config.head_dim is absent."""
+    assert not hasattr(model_without_head_dim.config, "head_dim")
+    press = CriticalAdaKVPress(press=KnormPress(compression_ratio=0.5))
+    with press(model_without_head_dim):
+        input_ids = torch.randint(0, 1024, (1, 128), device=model_without_head_dim.device)
+        model_without_head_dim(input_ids, past_key_values=DynamicCache()).past_key_values


### PR DESCRIPTION
## Summary

Fixes #213 — `CriticalKVPress` fails with `AttributeError` on models that don't expose `config.head_dim` (e.g. Qwen2).

## Change

Uses `getattr` with a fallback that derives `head_dim` from `hidden_size // num_attention_heads`:

```python
head_dim = getattr(module.config, "head_dim", None) or (
    module.config.hidden_size // module.config.num_attention_heads
)
```

## Testing

- **Regression test added** (`tests/presses/test_criticalkv_head_dim.py`): deletes `config.head_dim` from the unit-test model to simulate Qwen2-like configs. Without the fix, both tests fail with `AttributeError: 'LlamaConfig' object has no attribute 'head_dim'`.
- All existing tests pass (`python -m pytest tests` — 496 passed, 98 skipped)

## Checklist

- [x] Tests are working (`make test`)
- [x] Code is formatted correctly (`make style`)
- [x] Copyright header is included
- [x] All commits are signed-off using `git commit -s`

Signed-off-by: Johannes <johannes.gast@posteo.de>

---
*Generated with AI assistance*
