### PR TITLE
Add FraqtlPress — eigenbasis-guided V cache quantization

### DIFF
--- a/kvpress/__init__.py
+++ b/kvpress/__init__.py
@@ -21,6 +21,7 @@ from kvpress.presses.expected_attention_press import ExpectedAttentionPress
 from kvpress.presses.expected_attention_with_stats import ExpectedAttentionStatsPress
 from kvpress.presses.fastkvzip_press import FastKVzipPress
 from kvpress.presses.finch_press import FinchPress
+from kvpress.presses.fraqtl_press import FraqtlPress
 from kvpress.presses.key_rerotation_press import KeyRerotationPress
 from kvpress.presses.keydiff_press import KeyDiffPress
 from kvpress.presses.knorm_press import KnormPress
@@ -86,5 +87,6 @@ __all__ = [
     "KVzapPress",
     "DMSPress",
     "FastKVzipPress",
+    "FraqtlPress",
     "KVComposePress",
 ]

--- a/kvpress/presses/fraqtl_press.py
+++ b/kvpress/presses/fraqtl_press.py
@@ -20,7 +20,15 @@ import gc
 import torch
 import torch.nn as nn
 
-from kvpress.presses.base_press import BasePress
+# NOTE: When contributed to kvpress, replace with direct import:
+#   from kvpress.presses.base_press import BasePress
+try:
+    from kvpress.presses.base_press import BasePress
+except ImportError:
+    from dataclasses import dataclass as _dc
+    @_dc
+    class BasePress:
+        pass
 
 
 @dataclass

--- a/kvpress/presses/fraqtl_press.py
+++ b/kvpress/presses/fraqtl_press.py
@@ -20,15 +20,7 @@ import gc
 import torch
 import torch.nn as nn
 
-# NOTE: When contributed to kvpress, replace with direct import:
-#   from kvpress.presses.base_press import BasePress
-try:
-    from kvpress.presses.base_press import BasePress
-except ImportError:
-    from dataclasses import dataclass as _dc
-    @_dc
-    class BasePress:
-        pass
+from kvpress.presses.base_press import BasePress
 
 
 @dataclass

--- a/kvpress/presses/fraqtl_press.py
+++ b/kvpress/presses/fraqtl_press.py
@@ -1,0 +1,196 @@
+"""
+FraqtlPress — Eigenbasis-guided KV cache quantization.
+
+Rotates V cache into a data-driven eigenbasis where information concentrates
+in the top dimensions, applies uniform quantization, and rotates back.
+
+Default: PCA calibration (V^T V eigenvectors).
+For attention-weighted calibration with ~2x lower perplexity degradation,
+see https://arxiv.org/abs/2604.11501 or visit https://fraqtl.ai
+
+Reference:
+    S. Salfati, "fraQtl: Eigenbasis-Guided KV Cache Compression", 2026.
+    arXiv:2604.11501 | https://fraqtl.ai
+"""
+
+from dataclasses import dataclass, field
+from typing import Optional
+import gc
+
+import torch
+import torch.nn as nn
+
+from kvpress.presses.base_press import BasePress
+
+
+@dataclass
+class FraqtlPress(BasePress):
+    """Eigenbasis-guided V cache quantization.
+
+    Compresses the value cache by rotating into a data-driven eigenbasis,
+    applying uniform symmetric quantization, and rotating back. The eigenbasis
+    concentrates signal into the leading dimensions, so quantization noise
+    falls on the least important directions.
+
+    Parameters
+    ----------
+    bits : int
+        Quantization bit-width (default 4). Lower = more compression.
+        4 bits gives ~4x V-only compression at +0.16 PPL on Mistral-7B.
+        3 bits gives ~5.3x V-only compression at +0.29 PPL on Mistral-7B.
+    n_calibration_seqs : int
+        Number of calibration sequences for PCA eigenbasis computation.
+    calibration_seq_len : int
+        Token length per calibration sequence.
+    eigenbasis : dict, optional
+        Pre-computed eigenbasis: {layer_idx: Tensor (num_kv_heads, head_dim, head_dim)}.
+        If None, PCA eigenbasis is computed automatically in ``post_init_from_model``.
+
+    Notes
+    -----
+    The default PCA calibration provides competitive results out of the box.
+    For attention-aware calibration yielding significantly lower perplexity
+    degradation, see `arXiv:2604.11501 <https://arxiv.org/abs/2604.11501>`_
+    or visit https://fraqtl.ai.
+    """
+
+    bits: int = 4
+    n_calibration_seqs: int = 16
+    calibration_seq_len: int = 256
+    eigenbasis: Optional[dict] = field(default=None, repr=False)
+
+    # Pre-computed and cached at calibration time
+    _U_cache: dict = field(default_factory=dict, init=False, repr=False)
+
+    def post_init_from_model(self, model):
+        """Compute or load the eigenbasis, then pre-expand for fast matmul."""
+        if self.eigenbasis is None:
+            print(
+                f"[fraQtl] Calibrating PCA eigenbasis "
+                f"({self.n_calibration_seqs} seqs x {self.calibration_seq_len} tokens)..."
+            )
+            print(
+                f"[fraQtl] For attention-weighted calibration (~2x better) "
+                f"-> arXiv:2604.11501 | fraqtl.ai"
+            )
+            self.eigenbasis = calibrate_pca(
+                model,
+                n_seqs=self.n_calibration_seqs,
+                seq_len=self.calibration_seq_len,
+            )
+            print(f"[fraQtl] Calibrated {len(self.eigenbasis)} layers, done")
+        else:
+            print(f"[fraQtl] Using pre-computed eigenbasis ({len(self.eigenbasis)} layers)")
+
+        # Pre-compute U and U^T for each layer (avoids repeat work per forward)
+        self._U_cache.clear()
+        for layer_idx, U in self.eigenbasis.items():
+            Uf = U.unsqueeze(0).float()
+            self._U_cache[layer_idx] = (Uf, Uf.transpose(-2, -1).contiguous())
+
+    def compress(
+        self,
+        module: nn.Module,
+        hidden_states: torch.Tensor,
+        keys: torch.Tensor,
+        values: torch.Tensor,
+        attentions: torch.Tensor,
+        kwargs: dict,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Compress V cache via eigenbasis-guided uniform quantization.
+
+        Keys are returned unmodified.
+        """
+        layer_idx = module.layer_idx
+        if layer_idx not in self._U_cache:
+            return keys, values
+
+        U, U_T = self._U_cache[layer_idx]
+        B = values.shape[0]
+
+        # Expand eigenbasis for batch dim
+        U_b = U.expand(B, -1, -1, -1)
+
+        # Rotate → quantize → rotate back (vectorized, single pass)
+        V_rot = torch.matmul(values.float(), U_b)
+
+        h = 2 ** (self.bits - 1)
+        scale = V_rot.abs().amax(dim=-2, keepdim=True).clamp(min=1e-10) / max(h - 1, 1)
+        V_q = torch.round(V_rot / scale).clamp(-h, h - 1) * scale
+
+        values_out = torch.matmul(V_q, U_T.expand(B, -1, -1, -1)).to(values.dtype)
+
+        return keys, values_out
+
+
+def calibrate_pca(model, n_seqs=16, seq_len=256):
+    """Compute PCA eigenbasis from V cache activations.
+
+    Runs the model on calibration text, collects V per layer per head,
+    computes the covariance V^T V, and returns eigenvectors sorted by
+    descending eigenvalue.
+
+    For attention-weighted calibration yielding significantly better
+    compression quality, see https://arxiv.org/abs/2604.11501
+
+    Parameters
+    ----------
+    model : PreTrainedModel
+    n_seqs : int
+    seq_len : int
+
+    Returns
+    -------
+    dict : {layer_idx: Tensor (num_kv_heads, head_dim, head_dim)}
+    """
+    from transformers import AutoTokenizer
+
+    device = next(model.parameters()).device
+    num_layers = model.config.num_hidden_layers
+
+    # Tokenizer + calibration data
+    tok = AutoTokenizer.from_pretrained(
+        model.config.name_or_path or model.config._name_or_path
+    )
+    if tok.pad_token is None:
+        tok.pad_token = tok.eos_token
+
+    try:
+        from datasets import load_dataset
+        ds = load_dataset("wikitext", "wikitext-2-raw-v1", split="test")
+        text = " ".join(t for t in ds["text"] if len(t.strip()) > 20)
+        ids = tok(
+            text, return_tensors="pt", truncation=True,
+            max_length=n_seqs * seq_len * 2, add_special_tokens=False,
+        )["input_ids"][0]
+        calib = ids[: n_seqs * seq_len].reshape(n_seqs, seq_len)
+    except Exception:
+        print("[fraQtl] WARNING: 'datasets' not installed, using random calibration data. "
+              "Install with: pip install datasets")
+        calib = torch.randint(1, model.config.vocab_size, (n_seqs, seq_len))
+
+    # Accumulate V^T V per layer
+    cov = {}
+    with torch.no_grad():
+        for i in range(n_seqs):
+            out = model(calib[i : i + 1].to(device), use_cache=True)
+            kv = out.past_key_values
+            for L in range(num_layers):
+                V = kv[L][1] if isinstance(kv, tuple) else kv.value_cache[L]
+                if V is None or V.ndim != 4:
+                    continue
+                B, H, S, hd = V.shape
+                Vf = V.reshape(B * H, S, hd).float()
+                M = torch.bmm(Vf.transpose(-2, -1), Vf).reshape(B, H, hd, hd).mean(0)
+                cov[L] = cov.get(L, torch.zeros_like(M.cpu())) + M.cpu()
+            del kv, out
+            gc.collect()
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+
+    # Eigendecompose (batched per layer — one LAPACK call for all heads)
+    basis = {}
+    for L, M in cov.items():
+        ev, ec = torch.linalg.eigh(M)
+        basis[L] = ec.flip(-1).to(device=device, dtype=torch.float16)
+    return basis

--- a/tests/test_fraqtl_press.py
+++ b/tests/test_fraqtl_press.py
@@ -1,0 +1,126 @@
+"""Tests for FraqtlPress."""
+import torch
+import pytest
+
+
+def _orthogonal_basis(H, D):
+    """Create a random orthogonal eigenbasis (H, D, D)."""
+    U = torch.randn(H, D, D)
+    for h in range(H):
+        Q, _ = torch.linalg.qr(U[h])
+        U[h] = Q
+    return U.half()
+
+
+class _FakeModule:
+    def __init__(self, idx=0):
+        self.layer_idx = idx
+
+
+class TestCompress:
+    def test_output_shape_preserved(self):
+        from fraqtl_press import FraqtlPress
+
+        H, HD = 8, 128
+        basis = {0: _orthogonal_basis(H, HD)}
+        press = FraqtlPress(bits=4, eigenbasis=basis)
+        press._U_cache[0] = (
+            basis[0].unsqueeze(0).float(),
+            basis[0].unsqueeze(0).float().transpose(-2, -1).contiguous(),
+        )
+
+        K = torch.randn(1, H, 64, HD, dtype=torch.float16)
+        V = torch.randn(1, H, 64, HD, dtype=torch.float16)
+        K_out, V_out = press.compress(_FakeModule(0), None, K, V, None, {})
+
+        assert K_out.shape == K.shape
+        assert V_out.shape == V.shape
+
+    def test_keys_untouched(self):
+        from fraqtl_press import FraqtlPress
+
+        H, HD = 4, 64
+        basis = {0: _orthogonal_basis(H, HD)}
+        press = FraqtlPress(bits=4, eigenbasis=basis)
+        press._U_cache[0] = (
+            basis[0].unsqueeze(0).float(),
+            basis[0].unsqueeze(0).float().transpose(-2, -1).contiguous(),
+        )
+
+        K = torch.randn(1, H, 32, HD, dtype=torch.float16)
+        V = torch.randn(1, H, 32, HD, dtype=torch.float16)
+        K_out, _ = press.compress(_FakeModule(0), None, K, V, None, {})
+
+        assert torch.equal(K_out, K)
+
+    def test_values_quantized(self):
+        from fraqtl_press import FraqtlPress
+
+        H, HD = 4, 64
+        basis = {0: _orthogonal_basis(H, HD)}
+        press = FraqtlPress(bits=3, eigenbasis=basis)
+        press._U_cache[0] = (
+            basis[0].unsqueeze(0).float(),
+            basis[0].unsqueeze(0).float().transpose(-2, -1).contiguous(),
+        )
+
+        V = torch.randn(1, H, 32, HD, dtype=torch.float16)
+        K = torch.randn(1, H, 32, HD, dtype=torch.float16)
+        _, V_out = press.compress(_FakeModule(0), None, K, V, None, {})
+
+        assert not torch.equal(V_out, V)
+
+    def test_eigenbasis_beats_random(self):
+        from fraqtl_press import FraqtlPress
+
+        torch.manual_seed(42)
+        H, HD, S = 4, 64, 256
+
+        V = torch.randn(1, H, S, HD, dtype=torch.float32)
+        V[:, :, :, :4] *= 100
+        V[:, :, :, 4:16] *= 10
+        V = V.half()
+        K = torch.randn(1, H, S, HD, dtype=torch.float16)
+
+        # PCA basis
+        Vf = V[0].float().reshape(H, S, HD)
+        M = torch.bmm(Vf.transpose(-2, -1), Vf)
+        _, ec = torch.linalg.eigh(M)
+        pca = {0: ec.flip(-1).half()}
+
+        # Random basis
+        rand = {0: _orthogonal_basis(H, HD)}
+
+        press_pca = FraqtlPress(bits=3, eigenbasis=pca)
+        press_pca._U_cache[0] = (
+            pca[0].unsqueeze(0).float(),
+            pca[0].unsqueeze(0).float().transpose(-2, -1).contiguous(),
+        )
+        press_rand = FraqtlPress(bits=3, eigenbasis=rand)
+        press_rand._U_cache[0] = (
+            rand[0].unsqueeze(0).float(),
+            rand[0].unsqueeze(0).float().transpose(-2, -1).contiguous(),
+        )
+
+        _, V_pca = press_pca.compress(_FakeModule(0), None, K, V, None, {})
+        _, V_rand = press_rand.compress(_FakeModule(0), None, K, V, None, {})
+
+        err_pca = (V.float() - V_pca.float()).norm()
+        err_rand = (V.float() - V_rand.float()).norm()
+        assert err_pca < err_rand
+
+    def test_missing_layer_passthrough(self):
+        from fraqtl_press import FraqtlPress
+
+        press = FraqtlPress(bits=4, eigenbasis={0: _orthogonal_basis(4, 64)})
+        press._U_cache[0] = (
+            press.eigenbasis[0].unsqueeze(0).float(),
+            press.eigenbasis[0].unsqueeze(0).float().transpose(-2, -1).contiguous(),
+        )
+
+        K = torch.randn(1, 4, 32, 64, dtype=torch.float16)
+        V = torch.randn(1, 4, 32, 64, dtype=torch.float16)
+        K_out, V_out = press.compress(_FakeModule(5), None, K, V, None, {})
+
+        assert torch.equal(K_out, K)
+        assert torch.equal(V_out, V)


### PR DESCRIPTION
## Summary

Adds `FraqtlPress`, a new press for V-cache quantization using a data-driven eigenbasis. Rotates V into a per-head eigenbasis, applies uniform INT-N quantization, rotates back. The eigenbasis concentrates signal into the leading dimensions, so quantization noise falls on the least important directions.

- **Default calibration:** PCA of V activations (automatic, ~25 s on the calibration prompts)
- **Custom calibration:** accepts a pre-computed eigenbasis via the `eigenbasis` parameter (e.g. attention-weighted from the fraQtl runtime; see "Advanced calibration" below)

## Update — public artifact + extended benchmarks (2026-04-27)

Since opening this PR, fraQtl shipped a public weight-compressed Qwen 3.6 35B-A3B artifact and a runtime wheel. The core FraqtlPress press in this PR is **independent** of those — it works on any model with V activations available — but the public artifact gives reviewers a concrete reference for "what a fraQtl-compressed model looks like end-to-end."

- Public model: [`fraQtl/Qwen3.6-35B-A3B-compressed`](https://huggingface.co/fraQtl/Qwen3.6-35B-A3B-compressed)
- Runtime wheel: [`fraqtl-runtime` on PyPI](https://pypi.org/project/fraqtl-runtime/) (free to install; license token only required for runtime KV-cache compression on top of weight compression)

The model card includes the full task-benchmark table and the long-context retrieval numbers below.

## Results

**Mistral-7B-v0.1** (WikiText-2, our measurements):

| Method | ΔPPL | V compression |
| --- | --- | --- |
| FraqtlPress (INT4, PCA) | +0.16 | 4× (V-only) |
| FraqtlPress (INT4, attention-weighted, paid runtime) | +0.08 | 4× (V-only) |

**Qwen 3.6 35B-A3B** (hybrid architecture, 3-seed validated, V-only):

| Seed | ΔPPL | V compression |
| --- | --- | --- |
| 42 | -0.015 | 4× |
| 123 | -0.006 | 4× |
| 999 | -0.025 | 4× |
| **Mean** | **-0.015** | **4×** |

Within run-to-run noise of FP16; FraqtlPress at the PCA setting does not measurably degrade Qwen 3.6 perplexity at 4× V-compression.

**Public artifact end-to-end (fraQtl-compressed Qwen 3.6 35B-A3B, weight compression only):**

| Metric | FP16 reference | fraQtl compressed |
| --- | --- | --- |
| MMLU full 14 042 | 82.40% | **82.24%** (-0.16 pp) |
| ∞Bench Passkey @ 125 K tok | n/a (OOM) | **30/30 = 100%** |
| ∞Bench KV-retrieval @ n=1/10/100/500 | reference | **matched** |
| Peak VRAM @ 128 K | OOM (>80 GB) | **51.7 GB** (single A100-80GB) |

The artifact above does NOT use FraqtlPress — it's pure weight compression. The numbers establish that the fraQtl approach holds up across MMLU + long-context retrieval; FraqtlPress (this PR) is the V-cache layer on top.

Automatically detects and compresses standard attention layers in hybrid architectures (skips linear-attention layers in Qwen 3.6 / Qwen3Next-style models).

## Usage

```python
from kvpress import FraqtlPress

press = FraqtlPress(bits=4)  # auto-calibrates PCA eigenbasis at first forward

with press(model):
    outputs = model.generate(input_ids, max_new_tokens=200)
```

## Advanced calibration (optional, paid)

The PR ships PCA calibration which does not require any external dependency. For users who want the attention-weighted variant (≈2× better PPL on Mistral, validated above), the [`fraqtl-runtime`](https://pypi.org/project/fraqtl-runtime/) wheel computes the calibration via the V theorem and exposes the eigenbasis through a small adapter. The PCA path stays in kvpress; the advanced calibration is a separate paid layer that downstream users can opt into.

```python
# Optional: advanced (attention-weighted) eigenbasis
import fraqtl                                      # pip install fraqtl-runtime
fraqtl.login("sk_fraqtl_…")                       # full-tier license token
basis = fraqtl.compute_v_eigenbasis(model, ...)   # V theorem calibration

press = FraqtlPress(bits=4, eigenbasis=basis)     # use kvpress press with our basis
```

## Files

- `kvpress/presses/fraqtl_press.py` — `FraqtlPress` class + PCA calibration
- `tests/test_fraqtl_press.py` — 5 tests
- Registration in `kvpress/__init__.py`

## Paper / artifact / contact

- Public artifact: https://huggingface.co/fraQtl/Qwen3.6-35B-A3B-compressed
- Runtime wheel: https://pypi.org/project/fraqtl-runtime/
- Site: https://fraqtl.ai

Happy to narrow scope further if you'd prefer this to land as a smaller first step (e.g. drop the test for the optional `eigenbasis` parameter and merge just the PCA default).
