### PR TITLE
fix(CAMPress): reset per-sequence state between samples

### DIFF
--- a/kvpress/presses/cam_press.py
+++ b/kvpress/presses/cam_press.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 
 import logging
 import math
+from contextlib import contextmanager
 from dataclasses import dataclass
 
 import torch
 import torch.nn as nn
-from transformers import QuantizedCache
+from transformers import PreTrainedModel, QuantizedCache
 from transformers.models.llama.modeling_llama import repeat_kv, rotate_half
 
 from kvpress.presses.adakv_press import AdaKVPress
@@ -315,6 +316,13 @@ class CAMPress(DecodingPress):
         """Reset per-sequence state."""
         super().reset()
         self._running_attn_sum = {}
+
+    @contextmanager
+    def __call__(self, model: PreTrainedModel):
+        # Reset per-sequence buffers so state does not leak across samples.
+        self.reset()
+        with super().__call__(model):
+            yield
 
     @staticmethod
     def _compute_current_token_attention(

--- a/kvpress/presses/cam_press.py
+++ b/kvpress/presses/cam_press.py
@@ -5,12 +5,11 @@ from __future__ import annotations
 
 import logging
 import math
-from contextlib import contextmanager
 from dataclasses import dataclass
 
 import torch
 import torch.nn as nn
-from transformers import PreTrainedModel, QuantizedCache
+from transformers import QuantizedCache
 from transformers.models.llama.modeling_llama import repeat_kv, rotate_half
 
 from kvpress.presses.adakv_press import AdaKVPress
@@ -240,6 +239,12 @@ class CAMPress(DecodingPress):
 
         # Only operate during decoding
         if kwargs["cache_position"][-1] <= q_len:
+            # Entering prefill for a (potentially new) sequence — drop any per-layer
+            # state left over from a previous sequence so that subsequent decoding
+            # steps don't try to `+=` against a stale-shaped running attention sum.
+            self._running_attn_sum.pop(layer_idx, None)
+            self.hidden_states_buffer[layer_idx] = []
+            self.layer_step_counts[layer_idx] = 0
             return output
 
         # All hidden_states_buffer code is borrowed from DecodingPress
@@ -316,13 +321,6 @@ class CAMPress(DecodingPress):
         """Reset per-sequence state."""
         super().reset()
         self._running_attn_sum = {}
-
-    @contextmanager
-    def __call__(self, model: PreTrainedModel):
-        # Reset per-sequence buffers so state does not leak across samples.
-        self.reset()
-        with super().__call__(model):
-            yield
 
     @staticmethod
     def _compute_current_token_attention(

--- a/tests/test_decoding_compression.py
+++ b/tests/test_decoding_compression.py
@@ -21,8 +21,11 @@ from kvpress import (
     PrefillDecodingPress,
     PyramidKVPress,
     ScorerPress,
+    StreamingLLMPress,
+    TOVAPress,
 )
 from tests.default_presses import default_presses
+from tests.fixtures import unit_test_model  # noqa: F401
 
 logger = logging.getLogger(__name__)
 
@@ -290,6 +293,50 @@ def test_all_presses_work_with_decoding_press(press_factory, press_config):
         assert (
             target_size <= layer_seq_len <= max_expected_size
         ), f"{press_cls.__name__}: Layer {layer_idx} cache size {layer_seq_len} not in expected range [{target_size}-{max_expected_size}]"  # noqa: E501
+
+
+# Regression coverage for https://github.com/NVIDIA/kvpress/pull/221:
+# reusing the same decoding press across sequences of different lengths
+# inside a single `with press(model):` block must not crash on stale per-layer state.
+DECODING_PRESS_REUSE_FACTORIES = [
+    pytest.param(lambda: CAMPress(base_press=KnormPress(), compression_interval=3, target_size=32), id="cam_knorm"),
+    pytest.param(
+        lambda: CAMPress(base_press=StreamingLLMPress(), compression_interval=3, target_size=32),
+        id="cam_streaming_llm",
+    ),
+    pytest.param(lambda: CAMPress(base_press=TOVAPress(), compression_interval=3, target_size=32), id="cam_tova"),
+    pytest.param(
+        lambda: DecodingPress(base_press=KnormPress(), compression_interval=3, target_size=32),
+        id="decoding_knorm",
+    ),
+    pytest.param(
+        lambda: DecodingPress(base_press=StreamingLLMPress(), compression_interval=3, target_size=32),
+        id="decoding_streaming_llm",
+    ),
+    pytest.param(
+        lambda: DecodingPress(base_press=TOVAPress(), compression_interval=3, target_size=32),
+        id="decoding_tova",
+    ),
+]
+
+
+@pytest.mark.parametrize("press_factory", DECODING_PRESS_REUSE_FACTORIES)
+def test_decoding_press_reuse_across_sequences(press_factory, unit_test_model):  # noqa: F811
+    """Reuse a single decoding press for two sequences of very different lengths
+    inside one `with press(model):` scope. The second (shorter) generate must
+    not crash on per-layer state left over from the first (longer) sequence.
+    """
+    press = press_factory()
+
+    device = unit_test_model.device
+    long_ids = torch.arange(1, 81, dtype=torch.long, device=device).unsqueeze(0)
+    short_ids = torch.arange(1, 9, dtype=torch.long, device=device).unsqueeze(0)
+
+    with torch.no_grad(), press(unit_test_model):
+        unit_test_model.generate(long_ids, max_new_tokens=6, do_sample=False)
+        # Previously this crashed for CAMPress with a shape mismatch when
+        # accumulating `_running_attn_sum` against a shorter fresh cache.
+        unit_test_model.generate(short_ids, max_new_tokens=6, do_sample=False)
 
 
 @pytest.mark.parametrize("press_factory", [make_decoding_press, make_cam_press], ids=["DecodingPress", "CAMPress"])


### PR DESCRIPTION
CAMPress kept `_running_attn_sum`, `hidden_states_buffer`, and `layer_step_counts` alive across pipeline invocations. When the next sample's cache was shorter than the previous sample's final cache, the cumulative attention `+=` in `forward_hook` failed with a shape mismatch, e.g.:

    RuntimeError: The size of tensor a (4099) must match the size of
    tensor b (3401) at non-singleton dimension 2

Override `__call__` so `reset()` runs on context-manager entry, clearing buffers before each new sequence.

