### PR TITLE
Add TurboQuantPress

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Some presses rely on a different logic:
 - `FinchPress` ([source](kvpress/presses/finch_press.py), [paper](https://direct.mit.edu/tacl/article/doi/10.1162/tacl_a_00716/125280)): similar to SnapKV with a dynamic window size and key value re-rotation
 - `KVzipPress` ([source](kvpress/presses/kvzip_press.py), [paper](https://arxiv.org/abs/2505.23416)): identify redundant KV pairs through context reconstruction. Achieve near-lossless compression at the cost of multiple forward passes.
 - `KVComposePress` ([source](kvpress/presses/kvcompose_press.py), [paper](https://arxiv.org/abs/2509.05165)): attention-guided eviction, aligning per-head selections into composite tokens to preserve cache structure.
+- `TurboQuantPress` ([source](kvpress/presses/turboquant_press.py), [paper](https://arxiv.org/abs/2504.19874)): applies TurboQuant's random-rotation Lloyd-Max quantizer and QJL residual correction to KV tensors. In the current `BasePress` cache interface it stores dequantized tensors rather than a bit-packed cache.
 
 > [!NOTE]  
 > `KVComposePress` performs an extra pass over the full context, temporarily creating a KV cache of ~2x the context length and creating memory overhead during prefill.

--- a/evaluation/evaluate_registry.py
+++ b/evaluation/evaluate_registry.py
@@ -42,6 +42,7 @@ from kvpress import (
     StreamingLLMPress,
     ThinKPress,
     TOVAPress,
+    TurboQuantPress,
 )
 
 # These dictionaries define the available datasets, scorers, and KVPress methods for evaluation.
@@ -107,6 +108,7 @@ PRESS_REGISTRY = {
     "streaming_llm": StreamingLLMPress(),
     "think": ThinKPress(),
     "tova": TOVAPress(),
+    "turboquant": TurboQuantPress(),
     "compactor": CompactorPress(),
     "adakv_compactor": AdaKVPress(CompactorPress()),
     "no_press": None,

--- a/kvpress/__init__.py
+++ b/kvpress/__init__.py
@@ -42,6 +42,7 @@ from kvpress.presses.snapkv_press import SnapKVPress
 from kvpress.presses.streaming_llm_press import StreamingLLMPress
 from kvpress.presses.think_press import ThinKPress
 from kvpress.presses.tova_press import TOVAPress
+from kvpress.presses.turboquant_press import TurboQuantPress
 
 # Patch the attention functions to support head-wise compression
 patch_attention_functions()
@@ -63,6 +64,7 @@ __all__ = [
     "StreamingLLMPress",
     "ThinKPress",
     "TOVAPress",
+    "TurboQuantPress",
     "KVPressTextGenerationPipeline",
     "PerLayerCompressionPress",
     "KeyRerotationPress",

--- a/kvpress/presses/turboquant_press.py
+++ b/kvpress/presses/turboquant_press.py
@@ -1,0 +1,227 @@
+# SPDX-FileCopyrightText: Copyright (c) 1993-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import math
+from dataclasses import dataclass, field
+from typing import Literal
+
+import torch
+from torch import nn
+from transformers import QuantizedCache
+
+from kvpress.presses.base_press import BasePress
+from kvpress.utils import extract_keys_and_values
+
+TurboQuantObjective = Literal["mse", "prod"]
+
+
+@dataclass
+class TurboQuantPress(BasePress):
+    """
+    TurboQuant KV cache quantization.
+
+    This implements the algorithms from "TurboQuant: Online Vector Quantization with Near-optimal Distortion Rate"
+    (https://arxiv.org/abs/2504.19874):
+    - TurboQuant_mse: random rotation, Lloyd-Max scalar codebook, nearest-centroid quantization, inverse rotation.
+    - TurboQuant_prod: TurboQuant_mse with one fewer bit plus a 1-bit QJL residual correction.
+
+    The current BasePress interface stores the returned cache tensors in the model cache, so this press applies the
+    paper's quantize/dequantize transform to the KV tensors. It does not bit-pack the cache representation.
+
+    Parameters
+    ----------
+    bit_width : int, default=3
+        Bits per channel. For the `prod` objective, one bit is reserved for the QJL residual.
+    key_objective : {"mse", "prod"}, default="prod"
+        Quantizer used for keys. Keys are involved in query-key inner products, so `prod` follows the paper's
+        unbiased inner-product quantizer.
+    value_objective : {"mse", "prod"}, default="mse"
+        Quantizer used for values. Values are reconstructed vectors, so `mse` is the default.
+    seed : int, default=0
+        Seed for the paper's random rotation and QJL projection matrices.
+    codebook_grid_size : int, default=8193
+        Number of grid points used to numerically solve the one-dimensional continuous k-means problem.
+    max_lloyd_iterations : int, default=100
+        Maximum Lloyd-Max refinement iterations for the scalar codebook.
+    lloyd_tolerance : float, default=1e-6
+        Stop codebook refinement when all centroids move by less than this value.
+    full_precision_bits : int, default=16
+        Reference precision used only to expose an approximate `compression_ratio` attribute.
+    """
+
+    bit_width: int = 3
+    key_objective: TurboQuantObjective = "prod"
+    value_objective: TurboQuantObjective = "mse"
+    seed: int = 0
+    codebook_grid_size: int = 8193
+    max_lloyd_iterations: int = 100
+    lloyd_tolerance: float = 1e-6
+    full_precision_bits: int = 16
+    supports_decoding: bool = True
+    persistent_across_phases: bool = True
+    compression_ratio: float = field(init=False)
+    _codebook_cache: dict[tuple[int, int], torch.Tensor] = field(default_factory=dict, init=False, repr=False)
+    _rotation_cache: dict[tuple[int, str, int], torch.Tensor] = field(default_factory=dict, init=False, repr=False)
+    _projection_cache: dict[tuple[int, str, int], torch.Tensor] = field(default_factory=dict, init=False, repr=False)
+
+    def __post_init__(self):
+        assert isinstance(self.bit_width, int), "bit_width must be an integer"
+        assert 1 <= self.bit_width <= 8, "bit_width must be between 1 and 8"
+        assert self.key_objective in ("mse", "prod"), "key_objective must be 'mse' or 'prod'"
+        assert self.value_objective in ("mse", "prod"), "value_objective must be 'mse' or 'prod'"
+        assert self.codebook_grid_size >= 257, "codebook_grid_size must be at least 257"
+        assert self.max_lloyd_iterations > 0, "max_lloyd_iterations must be positive"
+        assert self.lloyd_tolerance > 0, "lloyd_tolerance must be positive"
+        assert self.full_precision_bits > 0, "full_precision_bits must be positive"
+        self.compression_ratio = max(0.0, 1.0 - self.bit_width / self.full_precision_bits)
+
+    def compress(
+        self,
+        module: nn.Module,
+        hidden_states: torch.Tensor,
+        keys: torch.Tensor,
+        values: torch.Tensor,
+        attentions: torch.Tensor,
+        kwargs: dict,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        del module, hidden_states, attentions, kwargs
+        return self._quantize_tensor(keys, self.key_objective), self._quantize_tensor(values, self.value_objective)
+
+    def forward_hook(self, module: nn.Module, input: list[torch.Tensor], kwargs: dict, output: list):
+        del input
+        hidden_states = kwargs["hidden_states"]
+        cache = kwargs["past_key_values"]
+        cache_layer = cache.layers[module.layer_idx]
+        q_len = hidden_states.shape[1]
+
+        keys, values = extract_keys_and_values(cache, module.layer_idx)
+        if kwargs["cache_position"][-1] > q_len:
+            key_prefix, key_suffix = keys[:, :, :-q_len, :], keys[:, :, -q_len:, :]
+            value_prefix, value_suffix = values[:, :, :-q_len, :], values[:, :, -q_len:, :]
+            keys = torch.cat([key_prefix, self._quantize_tensor(key_suffix, self.key_objective)], dim=2)
+            values = torch.cat([value_prefix, self._quantize_tensor(value_suffix, self.value_objective)], dim=2)
+        else:
+            keys, values = self.compress(module, hidden_states, keys, values, output[1], kwargs)
+
+        if isinstance(cache, QuantizedCache):
+            cache_layer._quantized_keys = cache_layer._quantize(keys, axis=cache_layer.axis_key)
+            cache_layer._quantized_values = cache_layer._quantize(values, axis=cache_layer.axis_value)
+            cache_layer.keys = torch.zeros(0, dtype=keys.dtype, device=keys.device)  # type: ignore[index]
+            cache_layer.values = torch.zeros(0, dtype=keys.dtype, device=keys.device)  # type: ignore[index]
+            cache_layer.cumulative_length = keys.shape[2]
+        else:
+            cache_layer.keys = keys
+            cache_layer.values = values
+
+        return output
+
+    def _quantize_tensor(self, tensor: torch.Tensor, objective: TurboQuantObjective) -> torch.Tensor:
+        shape = tensor.shape
+        vectors = tensor.reshape(-1, shape[-1])
+        quantized = self._quantize_vectors(vectors, objective)
+        return quantized.reshape(shape).to(dtype=tensor.dtype)
+
+    def _quantize_vectors(self, vectors: torch.Tensor, objective: TurboQuantObjective) -> torch.Tensor:
+        dtype = vectors.dtype
+        vectors = vectors.to(dtype=torch.float32)
+        norms = vectors.norm(dim=-1, keepdim=True)
+        unit_vectors = vectors / norms.clamp_min(torch.finfo(vectors.dtype).tiny)
+
+        if objective == "mse":
+            reconstructed = self._turboquant_mse(unit_vectors, self.bit_width)
+        else:
+            reconstructed = self._turboquant_prod(unit_vectors, self.bit_width)
+
+        return (reconstructed * norms).to(dtype=dtype)
+
+    def _turboquant_mse(self, unit_vectors: torch.Tensor, bit_width: int) -> torch.Tensor:
+        dimension = unit_vectors.shape[-1]
+        if bit_width == 0:
+            return torch.zeros_like(unit_vectors)
+
+        rotation = self._get_rotation(dimension, unit_vectors.device)
+        codebook = self._get_codebook(dimension, bit_width, unit_vectors.device)
+        boundaries = (codebook[:-1] + codebook[1:]) / 2
+
+        rotated = unit_vectors @ rotation.T
+        indices = torch.bucketize(rotated.contiguous(), boundaries)
+        quantized_rotated = codebook[indices]
+        return quantized_rotated @ rotation
+
+    def _turboquant_prod(self, unit_vectors: torch.Tensor, bit_width: int) -> torch.Tensor:
+        dimension = unit_vectors.shape[-1]
+        mse_reconstruction = self._turboquant_mse(unit_vectors, bit_width - 1)
+        residual = unit_vectors - mse_reconstruction
+        gamma = residual.norm(dim=-1, keepdim=True)
+        projection = self._get_projection(dimension, unit_vectors.device)
+
+        qjl = torch.where(
+            residual @ projection.T >= 0,
+            torch.ones((), dtype=unit_vectors.dtype, device=unit_vectors.device),
+            -torch.ones((), dtype=unit_vectors.dtype, device=unit_vectors.device),
+        )
+        qjl_reconstruction = math.sqrt(math.pi / 2) / dimension * gamma * (qjl @ projection)
+        return mse_reconstruction + qjl_reconstruction
+
+    def _get_rotation(self, dimension: int, device: torch.device) -> torch.Tensor:
+        key = (dimension, device.type, device.index or -1)
+        if key not in self._rotation_cache:
+            generator = torch.Generator(device="cpu").manual_seed(self.seed + 104729 * dimension)
+            gaussian = torch.randn(dimension, dimension, generator=generator, dtype=torch.float32)
+            q, r = torch.linalg.qr(gaussian)
+            signs = torch.sign(torch.diagonal(r))
+            signs = torch.where(signs == 0, torch.ones_like(signs), signs)
+            self._rotation_cache[key] = (q * signs.unsqueeze(0)).to(device=device)
+        return self._rotation_cache[key]
+
+    def _get_projection(self, dimension: int, device: torch.device) -> torch.Tensor:
+        key = (dimension, device.type, device.index or -1)
+        if key not in self._projection_cache:
+            generator = torch.Generator(device="cpu").manual_seed(self.seed + 1299709 * dimension)
+            projection = torch.randn(
+                dimension,
+                dimension,
+                generator=generator,
+                dtype=torch.float32,
+            )
+            self._projection_cache[key] = projection.to(device=device)
+        return self._projection_cache[key]
+
+    def _get_codebook(self, dimension: int, bit_width: int, device: torch.device) -> torch.Tensor:
+        key = (dimension, bit_width)
+        if key not in self._codebook_cache:
+            self._codebook_cache[key] = self._build_codebook(dimension, bit_width)
+        return self._codebook_cache[key].to(device=device)
+
+    def _build_codebook(self, dimension: int, bit_width: int) -> torch.Tensor:
+        if bit_width == 0:
+            return torch.zeros(1, dtype=torch.float32)
+
+        n_centroids = 2**bit_width
+        grid_size = max(self.codebook_grid_size, 64 * n_centroids + 1)
+        if grid_size % 2 == 0:
+            grid_size += 1
+
+        grid = torch.linspace(-1.0, 1.0, grid_size, dtype=torch.float64)
+        density_base = torch.clamp(1 - grid.square(), min=torch.finfo(torch.float64).tiny)
+        log_weights = (dimension - 3) / 2 * torch.log(density_base)
+        weights = torch.exp(log_weights - log_weights.max())
+
+        span = min(1.0, 3.0 / math.sqrt(dimension))
+        centroids = torch.linspace(-span, span, n_centroids, dtype=torch.float64)
+        for _ in range(self.max_lloyd_iterations):
+            boundaries = (centroids[:-1] + centroids[1:]) / 2
+            assignments = torch.bucketize(grid, boundaries)
+            updated = centroids.clone()
+            for idx in range(n_centroids):
+                mask = assignments == idx
+                bucket_weight = weights[mask].sum()
+                if bucket_weight > 0:
+                    updated[idx] = (grid[mask] * weights[mask]).sum() / bucket_weight
+
+            if torch.max(torch.abs(updated - centroids)) < self.lloyd_tolerance:
+                centroids = updated
+                break
+            centroids = updated
+
+        return centroids.to(dtype=torch.float32)

--- a/tests/default_presses.py
+++ b/tests/default_presses.py
@@ -26,6 +26,7 @@ from kvpress import (
     StreamingLLMPress,
     ThinKPress,
     TOVAPress,
+    TurboQuantPress,
 )
 from kvpress.presses.fastkvzip_press import FastKVzipGate
 from kvpress.presses.kvzap_press import KVzapConfig, KVzapModel
@@ -82,6 +83,13 @@ default_presses = [
         "kwargs": [{"compression_ratio": 0.2, "window_size": 2}, {"compression_ratio": 0.8, "window_size": 2}],
     },
     {"cls": TOVAPress, "kwargs": [{"compression_ratio": 0.2}, {"compression_ratio": 0.8}]},
+    {
+        "cls": TurboQuantPress,
+        "kwargs": [
+            {"bit_width": 3, "codebook_grid_size": 1025, "max_lloyd_iterations": 30},
+            {"bit_width": 2, "codebook_grid_size": 1025, "max_lloyd_iterations": 30},
+        ],
+    },
     {
         "cls": ThinKPress,
         "kwargs": [

--- a/tests/presses/test_turboquant_press.py
+++ b/tests/presses/test_turboquant_press.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 1993-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+
+from kvpress import TurboQuantPress
+
+
+def test_turboquant_preserves_shape_dtype_and_zero_vectors():
+    press = TurboQuantPress(bit_width=2, seed=7, codebook_grid_size=513, max_lloyd_iterations=20)
+    keys = torch.randn(2, 3, 5, 16, dtype=torch.float32)
+    zeros = torch.zeros_like(keys)
+
+    quantized = press._quantize_tensor(keys, "prod")
+    quantized_zeros = press._quantize_tensor(zeros, "prod")
+
+    assert quantized.shape == keys.shape
+    assert quantized.dtype == keys.dtype
+    assert torch.allclose(quantized_zeros, zeros)
+
+
+def test_turboquant_mse_error_decreases_with_bit_width():
+    generator = torch.Generator().manual_seed(0)
+    vectors = torch.randn(128, 16, generator=generator)
+    low_bit = TurboQuantPress(bit_width=1, seed=11, codebook_grid_size=513, max_lloyd_iterations=20)
+    high_bit = TurboQuantPress(bit_width=4, seed=11, codebook_grid_size=513, max_lloyd_iterations=20)
+
+    low_error = torch.mean((low_bit._quantize_vectors(vectors, "mse") - vectors) ** 2)
+    high_error = torch.mean((high_bit._quantize_vectors(vectors, "mse") - vectors) ** 2)
+
+    assert high_error < low_error


### PR DESCRIPTION
Closes #217.

## Summary

Adds `TurboQuantPress`, a data-oblivious KV-cache quantizer from
[TurboQuant: Online Vector Quantization with Near-optimal Distortion Rate](https://arxiv.org/abs/2504.19874).

Both objectives from the paper are implemented:
- `mse`: random rotation → Lloyd-Max scalar codebook → nearest-centroid → inverse rotation
- `prod` (default for keys): MSE quantizer at `b-1` bits + 1-bit QJL residual; an
  unbiased inner-product estimator

Defaults: `bit_width=3`, `key_objective="prod"`, `value_objective="mse"`.
Configurable `bit_width` in 1..8.

### Note on the cache representation

TurboQuant's natural encoding is `(idx, qjl_signs, ‖r‖)`. The current `BasePress`
interface stores float-valued cache tensors, so this implementation applies the
paper's quantize→dequantize transform and writes reconstructed bf16/fp16 tensors
back into the cache. It measures end-to-end quality at a given bit width but does
not deliver memory savings on its own; a bit-packed cache backend would be needed
for that. The docstring states this explicitly.

## Algorithm validation

Quantitative checks against the paper:
- **b=1 Lloyd-Max centroids** match `±√(2/(πd))` to 3 sig figs across `d ∈ {32, 64, 128, 1024}`
- **MSE distortion** at `b ∈ {1..4}` is `1.44×..2.39×` the lower bound `1/4^b`,
  consistent with the paper's `~2.7×` upper bound and the b=1 figure of `~1.45×`
- **`prod` is empirically unbiased** for `⟨y,x⟩`; `mse` is biased as expected
- **Rotation Π** is orthogonal to `~6e-7` residual

## Validation in this framework — the picture is more nuanced than the paper suggests

Per #217's request, end-to-end on LongBench `hotpotqa` (fraction=0.1, 20 samples,
seed=42, bf16, FA2):

| Model | no_press | b=8 | b=4 | b=3 |
|---|---:|---:|---:|---:|
| Llama-3.2-3B-Instruct | 60.83 | 63.89 | 58.06 (-4.5%) | 47.86 (-21%) |
| Qwen3-8B (q/k-norm) | 54.61 | 54.61 | 48.33 (-12%) | 9.09 (-83%) |
| Qwen2.5-7B-Instruct | 63.82 | 55.86 | 1.00 (-98%) | 0.00 (-100%) |

The paper's "3.5 bit ≈ neutral, 2.5 bit ≈ marginal" claim **replicates on Llama-3.2-3B**
(b=4 is `-4.5%`, in the "marginal" range), **partially holds on Qwen3-8B**, and
**collapses on Qwen2.5-7B** even at b=8.

### Hypothesized drivers (for downstream users to keep in mind)

Probing K tensors on the same input:

| Model | `‖K‖/√d` | rope_scaling | GQA (Q/KV) |
|---|---:|---|---:|
| Llama-3.2-3B | 1.57 | factor=32 | 3 |
| Qwen3-8B | 12.7 | none | 4 |
| Qwen2.5-7B | 24.2 | none | 7 |

Three independent factors plausibly stack:
1. **`rope_scaling`** (Llama-3.2 only) compresses long-context positions, smoothing
   attention so it tolerates K perturbations
2. **`q_norm`/`k_norm`** (Qwen3) bounds K magnitudes layer-to-layer
3. **GQA ratio**: a noisy KV head is shared by `Q/KV` query heads, so a higher
   ratio amplifies any quantization noise

Llama-3.2 has 1+3, Qwen3 has 2 + middling 3, Qwen2.5 has neither and the worst 3.

These are hypotheses from a small sample, not claims; the takeaway for users is
that TurboQuant's headline numbers are **architecture-sensitive** and worth
verifying on the target model before deploying low-bit-width settings.

## Tests

- `tests/presses/test_turboquant_press.py`: shape/dtype preservation, zero-vector
  fixed point, MSE distortion monotonically decreases with bit width
- Registered in `tests/default_presses.py`, so the existing
  `tests/presses/test_presses.py::test_presses_run` parametrization runs
  `TurboQuantPress` with `bit_width=2,3` through the pipeline against all 7
  wrapper presses — 8/8 pass.

## Test plan
- [x] `pytest tests/presses/test_turboquant_press.py`
- [x] `pytest tests/presses/test_presses.py -k TurboQuant`
