### PR TITLE
fix: Use scores.max().item() + 1 as window sentinel to prevent silent eviction

### DIFF
--- a/kvpress/presses/expected_attention_press.py
+++ b/kvpress/presses/expected_attention_press.py
@@ -160,6 +160,6 @@ class ExpectedAttentionPress(ScorerPress):
             scores = (scores + self.epsilon) * values.norm(dim=-1)
 
         # Add back the sink tokens. Use max score to make sure they are not pruned.
-        scores = F.pad(scores, (self.n_sink, 0), value=scores.max().item())
+        scores = F.pad(scores, (self.n_sink, 0), value=scores.max().item() + 1)
 
         return scores

--- a/kvpress/presses/finch_press.py
+++ b/kvpress/presses/finch_press.py
@@ -79,7 +79,7 @@ class FinchPress(BasePress):
         scores = scores.mean(dim=2)
 
         # Add back the observation window. Use max score to make sure the window is not pruned.
-        scores = F.pad(scores, (0, self.window_size), value=scores.max().item())
+        scores = F.pad(scores, (0, self.window_size), value=scores.max().item() + 1)
         return scores
 
     def compress(self, module, hidden_states, keys, values, attentions, kwargs):

--- a/kvpress/presses/snapkv_press.py
+++ b/kvpress/presses/snapkv_press.py
@@ -100,6 +100,6 @@ class SnapKVPress(ScorerPress):
         scores = scores.mean(2)
 
         # Add back the observation window. Use max score to make sure the window is not pruned.
-        scores = F.pad(scores, (0, self.window_size), value=scores.max().item())
+        scores = F.pad(scores, (0, self.window_size), value=scores.max().item() + 1)
 
         return scores

--- a/kvpress/presses/tova_press.py
+++ b/kvpress/presses/tova_press.py
@@ -56,6 +56,6 @@ class TOVAPress(ScorerPress):
         # Add back the last token. Use max score to make sure the window is not pruned.
         # This is a very slight difference from TOVA that don't enforce it, but the
         # last attention weight is usually very high so it should not change the results.
-        scores = F.pad(scores, (0, 1), value=scores.max().item())
+        scores = F.pad(scores, (0, 1), value=scores.max().item() + 1)
 
         return scores


### PR DESCRIPTION
Closes #226.

## Problem

`SnapKVPress`, `TOVAPress`, and `FinchPress` pad the observation window tokens at the **end** of the score tensor using `scores.max().item()` as a sentinel. `torch.topk` breaks ties by **smaller index**, so if any non-window token has a score equal to the max, it wins the tie and the window token is silently evicted.

## Fix

Replace `scores.max().item()` with `scores.max().item() + 1` in all three presses. This makes the sentinel strictly greater than every non-window score, guaranteeing the window is never pruned regardless of score distribution.

As discussed in #226, `float('inf')` is avoided because it can break score updates during decoding.

## Testing

Ran `tests/presses/test_presses.py` (181 tests) and `tests/presses/test_finch_press.py` — all pass.