### PR TITLE
Add CapPress

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Several presses inherit from `ScorerPress` ([source](kvpress/presses/scorer_pres
 - `CURPress` ([source](kvpress/presses/cur_press.py), [paper](https://arxiv.org/abs/2509.15038)): prune keys and values based on the CUR decomposition using approximate leverage scores.
 - `KVzapPress` ([source](kvpress/presses/kvzap/kvzap_press.py), [paper](https://arxiv.org/abs/2601.07891), [training](kvzap)): approximate KVzip+ using a fast surrogate model. To be used in conjunction with the `DMSPress`.
 - `FastKVzipPress` ([source](kvpress/presses/fastkvzip_press.py), [paper](https://arxiv.org/abs/2601.17668)): approximate KVzip through a lightweight gating mechanism.
+- `CapPress` ([source](kvpress/presses/cap_press.py), [paper](https://arxiv.org/abs/2604.25975)): evict tokens based on query-aware capacity scores from a log-determinant leverage proxy.
 
 Some presses rely on a different logic:
 - `ThinKPress` ([source](kvpress/presses/think_press.py), [paper](https://arxiv.org/abs/2407.21018)): compress the dimensions of the keys based on the channel attention score on the last queries 

--- a/kvpress/__init__.py
+++ b/kvpress/__init__.py
@@ -8,6 +8,7 @@ from kvpress.presses.adakv_press import AdaKVPress
 from kvpress.presses.base_press import SUPPORTED_MODELS, BasePress
 from kvpress.presses.block_press import BlockPress
 from kvpress.presses.cam_press import CAMPress
+from kvpress.presses.cap_press import CapPress
 from kvpress.presses.chunk_press import ChunkPress
 from kvpress.presses.chunkkv_press import ChunkKVPress
 from kvpress.presses.compactor_press import CompactorPress
@@ -87,4 +88,5 @@ __all__ = [
     "DMSPress",
     "FastKVzipPress",
     "KVComposePress",
+    "CapPress",
 ]

--- a/kvpress/presses/cap_press.py
+++ b/kvpress/presses/cap_press.py
@@ -1,0 +1,292 @@
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from dataclasses import dataclass
+
+import torch
+from torch import nn
+from torch.nn import functional as F
+from transformers.models.llama.modeling_llama import repeat_kv
+
+from kvpress.presses.scorer_press import ScorerPress
+from kvpress.utils import get_prerope_query_states
+
+
+@dataclass
+class CapPress(ScorerPress):
+    """
+    This scoring module implements the CAPKV algorithm proposed in the paper
+    (https://arxiv.org/abs/2604.25975).
+    The scoring function is derived from the following formulation:
+
+        A = I + sum_i w_i u_i u_i^T
+        s_i = w_i * u_i^T A^{-1} u_i
+        w_i = exp(tau * <k_i, mu_q>)
+
+    where mu_q is a historical-query anchor and u_i is approximated by the
+    value vector v_i.
+
+    Note:
+        1. For numerical stability, the keys and the historical-query anchor
+        are L2-normalized before the alignment is computed.
+        2. A per-head max shift is applied before exponentiation to avoid
+           numerical overflow.
+        3. For RoPE-based models, historical query states are first rotated by
+           an averaged future RoPE matrix before computing the query anchor.
+        4. The output-direction proxy is the raw value vector, u_i = v_i.
+    """
+
+    compression_ratio: float = 0.0
+
+    # hyperparameters.
+    tau: float = 5.0
+
+    # The following parameters are inherited from the implementation of Expected Attention (EA).
+    n_future_positions: int = 512
+    n_sink: int = 4
+    epsilon: float = 1e-6
+
+    def _query_states_pre_rope(
+        self,
+        module: nn.Module,
+        hidden_states: torch.Tensor,
+    ) -> torch.Tensor:
+        """
+        Project hidden states to query states before applying averaged RoPE.
+
+        Args:
+            module: Attention module used to project hidden states to queries.
+            hidden_states: Hidden states with shape [B, T, D_model].
+
+        Returns:
+            Query states with shape [B, H, T - n_sink, D_head].
+        """
+        hidden_states_no_sink = hidden_states[:, self.n_sink :]
+        return get_prerope_query_states(module, hidden_states_no_sink)
+
+    def _avg_rope_matrix(
+        self,
+        module: nn.Module,
+        q_len: int,
+        device: torch.device,
+        dtype: torch.dtype,
+    ) -> torch.Tensor:
+        """
+        Construct the average future RoPE rotation matrix.
+
+        Args:
+            module: Attention module exposing `rotary_emb` and `head_dim`.
+            q_len: Current sequence length.
+            device: Target device.
+            dtype: Target dtype.
+
+        Returns:
+            Averaged RoPE rotation matrix with shape [D_head, D_head].
+        """
+        position_ids = (
+            torch.arange(
+                q_len,
+                q_len + self.n_future_positions,
+            )
+            .unsqueeze(0)
+            .to(device)
+        )
+
+        head_dim = module.head_dim
+        dummy = torch.zeros((1, 1, head_dim), device=device, dtype=dtype)
+
+        cos, sin = module.rotary_emb(dummy, position_ids)
+        cos, sin = cos[0], sin[0]  # [n_future_positions, D_head]
+
+        identity = torch.eye(head_dim, device=device, dtype=dtype)
+        rotate_half = torch.zeros((head_dim, head_dim), device=device, dtype=dtype)
+        half_dim = head_dim // 2
+
+        rotate_half[half_dim:, :half_dim] = torch.eye(
+            half_dim,
+            device=device,
+            dtype=dtype,
+        )
+        rotate_half[:half_dim, half_dim:] = -torch.eye(
+            half_dim,
+            device=device,
+            dtype=dtype,
+        )
+
+        rotations = cos.unsqueeze(1) * identity + sin.unsqueeze(1) * rotate_half
+        return rotations.mean(dim=0)
+
+    def _apply_avg_rope(
+        self,
+        module: nn.Module,
+        query_states: torch.Tensor,
+        q_len: int,
+    ) -> torch.Tensor:
+        """
+        Apply averaged future RoPE rotation to query states.
+
+        Args:
+            module: Attention module.
+            query_states: Query states with shape [B, H, T', D_head].
+            q_len: Current sequence length.
+
+        Returns:
+            RoPE-adjusted query states with shape [B, H, T', D_head].
+        """
+        rotation = self._avg_rope_matrix(
+            module=module,
+            q_len=q_len,
+            device=query_states.device,
+            dtype=query_states.dtype,
+        )
+        return torch.matmul(query_states, rotation.T)
+
+    def _query_anchor(
+        self,
+        module: nn.Module,
+        hidden_states: torch.Tensor,
+    ) -> torch.Tensor:
+        """
+        Compute the historical-query anchor.
+
+        Args:
+            module: Attention module.
+            hidden_states: Hidden states with shape [B, T, D_model].
+
+        Returns:
+            Query anchor with shape [B, H, D_head].
+        """
+        q_len = hidden_states.shape[1]
+        query_states = self._query_states_pre_rope(module, hidden_states)
+        query_states = self._apply_avg_rope(module, query_states, q_len)
+        return query_states.mean(dim=2)
+
+    def _compute_query_key_statistic(
+        self,
+        query_anchor: torch.Tensor,
+        keys_rep: torch.Tensor,
+    ) -> torch.Tensor:
+        """
+        Compute the normalized query-key statistic.
+
+        Args:
+            query_anchor: Query anchor with shape [B, H, D_head].
+            keys_rep: Keys repeated to attention-head space, with shape
+                [B, H, T', D_head].
+
+        Returns:
+            Query-Key statistics with shape [B, H, T'].
+        """
+        query_anchor = F.normalize(query_anchor, p=2, dim=-1)
+        keys_rep = F.normalize(keys_rep, p=2, dim=-1)
+
+        statistic = torch.einsum("bhd,bhtd->bht", query_anchor, keys_rep)
+        return statistic.clamp(-1.0, 1.0)
+
+    def _compute_query_relevance_weights(
+        self,
+        statistic: torch.Tensor,
+    ) -> torch.Tensor:
+        """
+        Convert query-key statistics to non-negative relevance weights.
+
+        Args:
+            statistic: Query-key statistic with shape [B, H, T'].
+
+        Returns:
+            Relevance weights with shape [B, H, T'].
+        """
+        logits = self.tau * statistic
+        logits = logits - logits.amax(dim=-1, keepdim=True)
+        return torch.exp(logits)
+
+    def score(
+        self,
+        module: nn.Module,
+        hidden_states: torch.Tensor,
+        keys: torch.Tensor,
+        values: torch.Tensor,
+        attentions: torch.Tensor,
+        kwargs,
+    ) -> torch.Tensor:
+        """
+        Compute CAPKV retention scores.
+
+        Args:
+            module: Attention module.
+            hidden_states: Hidden states with shape [B, T, D_model].
+            keys: Cached keys with shape [B, H_kv, T_cache, D_head].
+            values: Cached values with shape [B, H_kv, T_cache, D_head].
+            attentions: Unused; included for KVPress scorer compatibility.
+            kwargs: Unused; included for KVPress scorer compatibility.
+
+        Returns:
+            Retention scores with shape [B, H_kv, T_cache]. Larger values
+            indicate higher retention priority.
+        """
+        del attentions, kwargs
+
+        if keys.size(2) <= self.n_sink:
+            raise ValueError(f"Input cache length ({keys.size(2)}) must be larger than " f"n_sink={self.n_sink}.")
+
+        keys_no_sink = keys[:, :, self.n_sink :]
+        values_no_sink = values[:, :, self.n_sink :]
+
+        batch_size, num_kv_heads, tprime, head_dim = keys_no_sink.shape
+        num_attention_heads = module.config.num_attention_heads
+
+        if num_attention_heads % num_kv_heads != 0:
+            raise ValueError(
+                "num_attention_heads must be divisible by num_kv_heads. "
+                f"Got num_attention_heads={num_attention_heads} and "
+                f"num_kv_heads={num_kv_heads}."
+            )
+
+        num_groups = num_attention_heads // num_kv_heads
+
+        # Repeat KV heads to attention-head space for query-aligned scoring.
+        keys_rep = repeat_kv(keys_no_sink, num_groups)
+        values_rep = repeat_kv(values_no_sink, num_groups)
+
+        # Query relevance.
+        query_anchor = self._query_anchor(module, hidden_states)
+        statistic = self._compute_query_key_statistic(query_anchor, keys_rep)
+        weights = self._compute_query_relevance_weights(statistic)
+
+        # Capacity vectors: CAPKV uses raw values as output-direction proxies.
+        capacity_vectors = values_rep
+
+        sqrt_weights = torch.sqrt(weights + self.epsilon).unsqueeze(-1)
+        scaled_vectors = capacity_vectors * sqrt_weights
+
+        identity = torch.eye(
+            head_dim,
+            device=scaled_vectors.device,
+            dtype=scaled_vectors.dtype,
+        ).view(1, 1, head_dim, head_dim)
+
+        capacity_matrix = identity + torch.einsum(
+            "bhtd,bhte->bhde",
+            scaled_vectors,
+            scaled_vectors,
+        )
+        capacity_matrix = capacity_matrix + self.epsilon * identity
+
+        capacity_matrix = capacity_matrix.to(dtype=torch.float32)
+
+        capacity_vectors_t = capacity_vectors.transpose(2, 3).to(dtype=torch.float32)
+        solution = torch.linalg.solve(capacity_matrix, capacity_vectors_t)
+
+        leverage = (capacity_vectors_t * solution).sum(dim=2)
+        scores_h = weights * leverage
+
+        # Average repeated attention-head scores back into KV-head space.
+        scores_h = scores_h.view(batch_size, num_kv_heads, num_groups, tprime)
+        scores_h = scores_h.mean(dim=2)
+
+        # Assign the maximum score to sink tokens to preserve them under
+        # standard top-k retention.
+        max_score = scores_h.max().item()
+        scores = F.pad(scores_h, (self.n_sink, 0), value=max_score)
+
+        return scores

--- a/tests/default_presses.py
+++ b/tests/default_presses.py
@@ -4,6 +4,7 @@
 import numpy as np
 
 from kvpress import (
+    CapPress,
     CompactorPress,
     CURPress,
     DuoAttentionPress,
@@ -151,4 +152,5 @@ default_presses = [
             {"structured": False, "compression_ratio": 0.8},
         ],
     },
+    {"cls": CapPress, "kwargs": [{"compression_ratio": 0.5}, {"compression_ratio": 0.8}]},
 ]

--- a/tests/presses/test_cap_press.py
+++ b/tests/presses/test_cap_press.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+
+from kvpress import CapPress
+from tests.fixtures import unit_test_model  # noqa: F401
+
+
+def test_compactor_press(unit_test_model):  # noqa: F811
+    for press in [
+        CapPress(compression_ratio=0.5, tau=5.0),
+        CapPress(compression_ratio=0.8, tau=5.0),
+        CapPress(compression_ratio=0.8, tau=10.0),
+        CapPress(compression_ratio=0.8, tau=5.0, n_sink=8),
+    ]:
+        with press(unit_test_model):
+            input_ids = torch.arange(10, 40).to(unit_test_model.device)
+            unit_test_model(input_ids.unsqueeze(0), use_cache=True)


### PR DESCRIPTION
## PR description

Add `CapPress`, a new KV cache compression method implementing CAPKV from paper(https://arxiv.org/abs/2604.25975). The press evicts tokens based on query-aware capacity scores computed from a log-determinant leverage proxy, using value vectors as output-direction proxies with historical-query anchoring.