### PR TITLE
feat: Add ZigZagKVPress for dynamic per-layer KV cache compression

### DIFF
--- a/evaluation/evaluate.py
+++ b/evaluation/evaluate.py
@@ -371,18 +371,26 @@ class EvaluationRunner:
             model_kwargs["quantization_config"] = FineGrainedFP8Config()
             logger.info("FP8 quantization enabled.")
 
-        if isinstance(self.press, ObservedAttentionPress):
+        from kvpress import ZigZagKVPress
+
+        if isinstance(self.press, (ObservedAttentionPress, ZigZagKVPress)):
             model_kwargs["attn_implementation"] = "eager"
-            logger.info("ObservedAttentionPress detected, setting attn_implementation to 'eager'.")
+            logger.info(f"{type(self.press).__name__} detected, setting attn_implementation to 'eager'.")
         else:
             try:
-                import flash_attn  # noqa: F401
+                import flash_attn_3  # noqa: F401
 
-                model_kwargs["attn_implementation"] = "flash_attention_2"
-                logger.info("Flash Attention 2 detected, setting attn_implementation to 'flash_attention_2'.")
+                model_kwargs["attn_implementation"] = "flash_attention_3"
+                logger.info("Flash Attention 3 detected, setting attn_implementation to 'flash_attention_3'.")
             except ImportError:
-                logger.info("Flash Attention 2 not available, using default attn_implementation.")
-                pass
+                try:
+                    import flash_attn  # noqa: F401
+
+                    model_kwargs["attn_implementation"] = "flash_attention_2"
+                    logger.info("Flash Attention 2 detected, setting attn_implementation to 'flash_attention_2'.")
+                except ImportError:
+                    logger.info("Flash Attention not available, using default attn_implementation.")
+                    pass
 
         logger.info(f"Loading model pipeline for: {model_name} on device: {device} with model_kwargs: {model_kwargs}")
         pipeline_kwargs = {

--- a/evaluation/evaluate.py
+++ b/evaluation/evaluate.py
@@ -371,9 +371,7 @@ class EvaluationRunner:
             model_kwargs["quantization_config"] = FineGrainedFP8Config()
             logger.info("FP8 quantization enabled.")
 
-        from kvpress import ZigZagKVPress
-
-        if isinstance(self.press, (ObservedAttentionPress, ZigZagKVPress)):
+        if isinstance(self.press, ObservedAttentionPress):
             model_kwargs["attn_implementation"] = "eager"
             logger.info(f"{type(self.press).__name__} detected, setting attn_implementation to 'eager'.")
         else:

--- a/evaluation/evaluate_registry.py
+++ b/evaluation/evaluate_registry.py
@@ -43,6 +43,7 @@ from kvpress import (
     StreamingLLMPress,
     ThinKPress,
     TOVAPress,
+    ZigZagKVPress,
 )
 
 # These dictionaries define the available datasets, scorers, and KVPress methods for evaluation.
@@ -110,6 +111,7 @@ PRESS_REGISTRY = {
     "tova": TOVAPress(),
     "compactor": CompactorPress(),
     "adakv_compactor": AdaKVPress(CompactorPress()),
+    "zigzag_observed": ZigZagKVPress(press=ObservedAttentionPress()),
     "no_press": None,
     "cam_streaming_llm": CAMPress(base_press=StreamingLLMPress()),
     "cam_knorm": CAMPress(base_press=KnormPress()),

--- a/evaluation/evaluate_registry.py
+++ b/evaluation/evaluate_registry.py
@@ -111,7 +111,7 @@ PRESS_REGISTRY = {
     "tova": TOVAPress(),
     "compactor": CompactorPress(),
     "adakv_compactor": AdaKVPress(CompactorPress()),
-    "zigzag_observed": ZigZagKVPress(press=ObservedAttentionPress()),
+    "zigzag_snapkv": ZigZagKVPress(press=SnapKVPress()),
     "no_press": None,
     "cam_streaming_llm": CAMPress(base_press=StreamingLLMPress()),
     "cam_knorm": CAMPress(base_press=KnormPress()),

--- a/kvpress/__init__.py
+++ b/kvpress/__init__.py
@@ -44,6 +44,7 @@ from kvpress.presses.snapkv_press import SnapKVPress
 from kvpress.presses.streaming_llm_press import StreamingLLMPress
 from kvpress.presses.think_press import ThinKPress
 from kvpress.presses.tova_press import TOVAPress
+from kvpress.presses.zigzag_press import ZigZagKVPress
 
 # Patch the attention functions to support head-wise compression
 patch_attention_functions()
@@ -91,4 +92,5 @@ __all__ = [
     "KVComposePress",
     "MergingPress",
     "CapPress",
+    "ZigZagKVPress",
 ]

--- a/kvpress/presses/zigzag_press.py
+++ b/kvpress/presses/zigzag_press.py
@@ -1,0 +1,278 @@
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
+import logging
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from typing import Generator, Optional
+
+import torch
+from torch import nn
+from transformers import PreTrainedModel, QuantizedCache
+
+from kvpress.presses.base_press import SUPPORTED_MODELS, BasePress
+from kvpress.presses.scorer_press import ScorerPress
+from kvpress.utils import extract_keys_and_values
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ZigZagKVPress(BasePress):
+    """
+    Dynamic per-layer KV cache compression based on attention entropy.
+
+    Wrapper press that dynamically allocates per-layer KV cache budgets based on
+    layer uncertainty (measured via LMBA — Layer Minimum Budget to maintain Attention).
+    Layers with diffuse attention (high entropy) get larger budgets; layers with
+    concentrated attention (low entropy) get smaller budgets.
+
+    Based on ZigZagKV (https://arxiv.org/abs/2412.09036, COLING 2025).
+
+    The algorithm works in two phases within a single forward pass:
+    1. **Collect phase**: Forward hooks record attention weights and compute LMBA per layer.
+    2. **Compress phase**: After the forward pass completes, per-layer budgets are computed
+       using the uncertainty-based formula and the inner press compresses each layer.
+
+    Parameters
+    ----------
+    press : ScorerPress
+        The underlying scoring method used for token selection within each layer.
+    compression_ratio : float, default=0.0
+        Average fraction of tokens to remove across all layers.
+    window_size : int, default=64
+        Number of recent tokens whose attention weights are used to compute LMBA.
+    attention_threshold : float, default=0.9
+        Fraction of cumulative attention mass used to determine LMBA.
+    b_bound_ratio : float, default=0.1
+        Minimum budget per layer as a fraction of the average budget size.
+        Prevents any layer from being overly compressed.
+    """
+
+    press: ScorerPress = field(default_factory=lambda: ScorerPress())
+    compression_ratio: float = 0.0
+    window_size: int = 64
+    attention_threshold: float = 0.9
+    b_bound_ratio: float = 0.1
+
+    _lmba_values: list = field(default_factory=list, init=False, repr=False)
+    _layer_data: list = field(default_factory=list, init=False, repr=False)
+    _cache_ref: Optional[object] = field(default=None, init=False, repr=False)
+
+    def __post_init__(self):
+        assert 0 <= self.compression_ratio < 1, "compression_ratio must be between 0 and 1"
+        assert 0 < self.attention_threshold <= 1, "attention_threshold must be between 0 and 1"
+        assert 0 <= self.b_bound_ratio < 1, "b_bound_ratio must be between 0 and 1"
+        assert isinstance(self.press, ScorerPress), "ZigZagKVPress requires a ScorerPress as the inner press"
+
+    def _compute_lmba(self, attentions: torch.Tensor, k_len: int) -> float:
+        """
+        Compute LMBA (Layer Minimum Budget to maintain Attention) for a single layer.
+
+        For each attention head, finds the minimum number of tokens needed to
+        capture `attention_threshold` of the total attention mass, using the
+        last `window_size` query positions. Returns the average across all heads and batches.
+        """
+        bsz, num_heads, q_len, _ = attentions.shape
+
+        window = min(self.window_size, q_len)
+        attn = attentions[:, :, -window:, :]
+
+        # Average attention over the window queries: (bsz, num_heads, k_len)
+        avg_attn = attn.mean(dim=2)
+
+        # Sort descending and compute cumulative sum to find MBA per head
+        sorted_attn, _ = avg_attn.sort(dim=-1, descending=True)
+        cumsum = sorted_attn.cumsum(dim=-1)
+
+        # MBA = first position where cumulative attention >= threshold
+        threshold = self.attention_threshold * avg_attn.sum(dim=-1, keepdim=True)
+        mba = (cumsum < threshold).sum(dim=-1) + 1
+        mba = mba.clamp(max=k_len)
+
+        return mba.float().mean().item()
+
+    def forward_hook(self, module: nn.Module, input: list[torch.Tensor], kwargs: dict, output: list):
+        """
+        Collection hook: compute LMBA and cache layer data for deferred compression.
+        """
+        hidden_states = kwargs["hidden_states"]
+        q_len = hidden_states.shape[1]
+
+        if kwargs["cache_position"][-1] > q_len:
+            return output
+
+        cache = kwargs["past_key_values"]
+        if self._cache_ref is None:
+            self._cache_ref = cache
+
+        attentions = output[1]
+        if attentions is None:
+            raise ValueError(
+                "ZigZagKVPress requires attention weights. "
+                'Use attn_implementation="eager" when loading the model.'
+            )
+
+        keys, values = extract_keys_and_values(cache, module.layer_idx)
+        k_len = keys.shape[2]
+
+        lmba = self._compute_lmba(attentions, k_len)
+        self._lmba_values.append(lmba)
+
+        self._layer_data.append({
+            "layer_idx": module.layer_idx,
+            "module": module,
+            "hidden_states": hidden_states,
+            "keys": keys,
+            "values": values,
+            "attentions": attentions,
+            "kwargs": kwargs,
+        })
+
+        return output
+
+    def _compute_compression_ratios(self, seq_len: int) -> list[float]:
+        """
+        Convert LMBA values to per-layer compression ratios.
+
+        Uses the ZigZagKV budget allocation formula (Equation 6 from the paper):
+            uncertainty_l = LMBA_l / sum(LMBA)
+            budget_l = B_bound + (B_avg - B_bound) * L * uncertainty_l
+            compression_ratio_l = 1 - budget_l / seq_len
+        """
+        num_layers = len(self._lmba_values)
+        total_lmba = sum(self._lmba_values)
+
+        if total_lmba == 0:
+            return [self.compression_ratio] * num_layers
+
+        b_avg = seq_len * (1 - self.compression_ratio)
+        b_bound = b_avg * self.b_bound_ratio
+
+        ratios = []
+        for lmba in self._lmba_values:
+            uncertainty = lmba / total_lmba
+            budget = b_bound + (b_avg - b_bound) * num_layers * uncertainty
+            budget = max(1.0, min(budget, float(seq_len)))
+            ratio = 1.0 - budget / seq_len
+            ratio = max(0.0, min(ratio, 1.0 - 1.0 / seq_len))
+            ratios.append(ratio)
+
+        return ratios
+
+    def _apply_compression(self):
+        """
+        Phase 2: compress all layers using dynamically computed per-layer ratios.
+
+        All layers are padded to the same final length (the maximum across layers)
+        to ensure compatibility with HuggingFace's attention mask mechanism, which
+        expects uniform cache sizes across layers.
+        """
+        if not self._layer_data:
+            return
+
+        cache = self._cache_ref
+        seq_len = self._layer_data[0]["keys"].shape[2]
+        compression_ratios = self._compute_compression_ratios(seq_len)
+
+        logger.debug(
+            f"ZigZagKV per-layer compression ratios: "
+            f"min={min(compression_ratios):.3f}, max={max(compression_ratios):.3f}, "
+            f"mean={sum(compression_ratios) / len(compression_ratios):.3f}"
+        )
+
+        compressed_layers = []
+        for data, ratio in zip(self._layer_data, compression_ratios):
+            module = data["module"]
+
+            original_ratio = self.press.compression_ratio
+            self.press.compression_ratio = ratio
+
+            keys, values = self.press.compress(
+                module,
+                data["hidden_states"],
+                data["keys"],
+                data["values"],
+                data["attentions"],
+                data["kwargs"],
+            )
+
+            self.press.compression_ratio = original_ratio
+            compressed_layers.append((data["layer_idx"], keys, values))
+
+        max_len = max(k.shape[2] for _, k, _ in compressed_layers)
+
+        for layer_idx, keys, values in compressed_layers:
+            pad_len = max_len - keys.shape[2]
+            if pad_len > 0:
+                keys = torch.cat([
+                    keys,
+                    torch.zeros(*keys.shape[:2], pad_len, keys.shape[3], dtype=keys.dtype, device=keys.device),
+                ], dim=2)
+                values = torch.cat([
+                    values,
+                    torch.zeros(*values.shape[:2], pad_len, values.shape[3], dtype=values.dtype, device=values.device),
+                ], dim=2)
+
+            cache_layer = cache.layers[layer_idx]
+            if isinstance(cache, QuantizedCache):
+                cache_layer._quantized_keys = cache_layer._quantize(keys, axis=cache_layer.axis_key)
+                cache_layer._quantized_values = cache_layer._quantize(values, axis=cache_layer.axis_value)
+                cache_layer.keys = torch.zeros(0, dtype=keys.dtype, device=keys.device)
+                cache_layer.values = torch.zeros(0, dtype=keys.dtype, device=keys.device)
+                cache_layer.cumulative_length = keys.shape[2]
+            else:
+                cache_layer.keys = keys
+                cache_layer.values = values
+
+    @contextmanager
+    def __call__(self, model: PreTrainedModel) -> Generator:
+        """
+        Context manager that applies ZigZagKV compression.
+
+        Registers hooks to collect attention patterns during prefill, then
+        compresses all layers with dynamically computed per-layer budgets
+        when the context manager exits.
+
+        Parameters
+        ----------
+        model : PreTrainedModel
+            The transformer model to apply compression to.
+
+        Examples
+        --------
+        >>> from kvpress import ZigZagKVPress, SnapKVPress
+        >>> press = ZigZagKVPress(press=SnapKVPress(window_size=32), compression_ratio=0.5)
+        >>> with press(model):
+        ...     outputs = model(input_ids, past_key_values=cache)
+        """
+        from transformers import Gemma3ForConditionalGeneration
+
+        if not isinstance(model, SUPPORTED_MODELS):
+            logger.warning(f"Model {type(model)} not tested, supported models: {SUPPORTED_MODELS}")
+
+        self._lmba_values = []
+        self._layer_data = []
+        self._cache_ref = None
+        self.press.post_init_from_model(model)
+        self.post_init_from_model(model)
+
+        hooks = []
+        try:
+            language_model = model.model.language_model if hasattr(model.model, "language_model") else model.model
+            for layer in language_model.layers:
+                if isinstance(model, Gemma3ForConditionalGeneration) and layer.self_attn.is_sliding:
+                    continue
+                layer.self_attn.rotary_emb = language_model.rotary_emb
+                hooks.append(layer.self_attn.register_forward_hook(self.forward_hook, with_kwargs=True))
+            yield
+        finally:
+            for hook in hooks:
+                hook.remove()
+
+            self._apply_compression()
+
+            self._lmba_values = []
+            self._layer_data = []
+            self._cache_ref = None

--- a/kvpress/presses/zigzag_press.py
+++ b/kvpress/presses/zigzag_press.py
@@ -13,6 +13,7 @@ from transformers import PreTrainedModel, QuantizedCache
 
 from kvpress.presses.base_press import SUPPORTED_MODELS, BasePress
 from kvpress.presses.scorer_press import ScorerPress
+from kvpress.presses.snapkv_press import SnapKVPress
 from kvpress.utils import extract_keys_and_values
 
 logger = logging.getLogger(__name__)
@@ -21,85 +22,125 @@ logger = logging.getLogger(__name__)
 @dataclass
 class ZigZagKVPress(BasePress):
     """
-    Dynamic per-layer KV cache compression based on attention entropy.
+    Dynamic per-layer KV cache compression based on attention concentration.
 
-    Wrapper press that dynamically allocates per-layer KV cache budgets based on
-    layer uncertainty (measured via LMBA — Layer Minimum Budget to maintain Attention).
-    Layers with diffuse attention (high entropy) get larger budgets; layers with
-    concentrated attention (low entropy) get smaller budgets.
+    Wrapper press that allocates per-layer KV cache budgets based on each layer's
+    uncertainty, measured via LMBA (Layer Minimum Budget to maintain Attention).
+    Layers with diffuse attention (high LMBA) receive larger budgets; layers with
+    concentrated attention (low LMBA) receive smaller budgets. The total budget is
+    conserved so the average compression ratio matches ``compression_ratio``.
 
     Based on ZigZagKV (https://arxiv.org/abs/2412.09036, COLING 2025).
 
-    The algorithm works in two phases within a single forward pass:
-    1. **Collect phase**: Forward hooks record attention weights and compute LMBA per layer.
-    2. **Compress phase**: After the forward pass completes, per-layer budgets are computed
-       using the uncertainty-based formula and the inner press compresses each layer.
+    Unlike a naive implementation, this press is flash-attention compatible: it does
+    not require ``attn_implementation="eager"``. Importance scores (and LMBA) are
+    derived from the inner press's score function, which for SnapKV-style presses
+    recomputes a small observation-window attention internally. Compression is
+    applied with a single lightweight deferral: per-layer LMBA scalars and score
+    tensors are collected during the forward pass, the global budget allocation is
+    computed once all layers are seen, and each layer is then physically resized
+    (genuine per-layer cache sizes, no padding).
 
     Parameters
     ----------
-    press : ScorerPress
-        The underlying scoring method used for token selection within each layer.
+    press : ScorerPress, default=SnapKVPress()
+        The underlying scoring method used to rank tokens within each layer.
+        An attention-based press such as SnapKVPress is recommended so that LMBA
+        reflects the attention distribution.
     compression_ratio : float, default=0.0
-        Average fraction of tokens to remove across all layers.
-    window_size : int, default=64
-        Number of recent tokens whose attention weights are used to compute LMBA.
+        Target average fraction of tokens to remove across all layers.
     attention_threshold : float, default=0.9
-        Fraction of cumulative attention mass used to determine LMBA.
-    b_bound_ratio : float, default=0.1
-        Minimum budget per layer as a fraction of the average budget size.
-        Prevents any layer from being overly compressed.
+        Fraction of cumulative score mass used to determine LMBA per layer.
+    b_bound_ratio : float, default=0.2
+        Minimum per-layer budget as a fraction of the average budget. Prevents any
+        single layer from being starved of tokens.
     """
 
-    press: ScorerPress = field(default_factory=lambda: ScorerPress())
+    press: ScorerPress = field(default_factory=SnapKVPress)
     compression_ratio: float = 0.0
-    window_size: int = 64
     attention_threshold: float = 0.9
-    b_bound_ratio: float = 0.1
+    b_bound_ratio: float = 0.2
 
-    _lmba_values: list = field(default_factory=list, init=False, repr=False)
-    _layer_data: list = field(default_factory=list, init=False, repr=False)
+    _collected: list = field(default_factory=list, init=False, repr=False)
     _cache_ref: Optional[object] = field(default=None, init=False, repr=False)
 
     def __post_init__(self):
+        assert isinstance(self.press, ScorerPress), "ZigZagKVPress requires a ScorerPress as the inner press"
         assert 0 <= self.compression_ratio < 1, "compression_ratio must be between 0 and 1"
         assert 0 < self.attention_threshold <= 1, "attention_threshold must be between 0 and 1"
         assert 0 <= self.b_bound_ratio < 1, "b_bound_ratio must be between 0 and 1"
-        assert isinstance(self.press, ScorerPress), "ZigZagKVPress requires a ScorerPress as the inner press"
 
-    def _compute_lmba(self, attentions: torch.Tensor, k_len: int) -> float:
+    def post_init_from_model(self, model: PreTrainedModel):
+        self.press.post_init_from_model(model)
+
+    def _compute_lmba(self, scores: torch.Tensor) -> float:
         """
-        Compute LMBA (Layer Minimum Budget to maintain Attention) for a single layer.
+        Compute LMBA (Layer Minimum Budget to maintain Attention) for one layer.
 
-        For each attention head, finds the minimum number of tokens needed to
-        capture `attention_threshold` of the total attention mass, using the
-        last `window_size` query positions. Returns the average across all heads and batches.
+        LMBA is the average number of tokens needed to accumulate
+        ``attention_threshold`` of the total score mass, measured per head and
+        averaged across heads and batch. Concentrated attention (mass in few
+        tokens) gives a low LMBA; diffuse attention gives a high LMBA.
+
+        Parameters
+        ----------
+        scores : torch.Tensor
+            Importance scores of shape (batch, num_kv_heads, k_len).
         """
-        bsz, num_heads, q_len, _ = attentions.shape
-
-        window = min(self.window_size, q_len)
-        attn = attentions[:, :, -window:, :]
-
-        # Average attention over the window queries: (bsz, num_heads, k_len)
-        avg_attn = attn.mean(dim=2)
-
-        # Sort descending and compute cumulative sum to find MBA per head
-        sorted_attn, _ = avg_attn.sort(dim=-1, descending=True)
-        cumsum = sorted_attn.cumsum(dim=-1)
-
-        # MBA = first position where cumulative attention >= threshold
-        threshold = self.attention_threshold * avg_attn.sum(dim=-1, keepdim=True)
+        k_len = scores.shape[-1]
+        # Use only non-negative mass for a well-defined cumulative distribution.
+        mass = scores.float().clamp(min=0.0)
+        sorted_mass, _ = mass.sort(dim=-1, descending=True)
+        cumsum = sorted_mass.cumsum(dim=-1)
+        total = sorted_mass.sum(dim=-1, keepdim=True)
+        threshold = self.attention_threshold * total
+        # Number of tokens to reach the threshold (at least 1).
         mba = (cumsum < threshold).sum(dim=-1) + 1
         mba = mba.clamp(max=k_len)
-
         return mba.float().mean().item()
+
+    def _compute_budgets(self, lmba_values: list[float], seq_len: int) -> list[int]:
+        """
+        Convert per-layer LMBA values into integer per-layer token budgets.
+
+        Uses the ZigZagKV allocation rule (Equation 6 from the paper):
+            uncertainty_l = LMBA_l / sum_k(LMBA_k)
+            budget_l = B_bound + (B_avg - B_bound) * L * uncertainty_l
+
+        The total budget sums to L * B_avg, so the average compression ratio is
+        preserved.
+        """
+        num_layers = len(lmba_values)
+        total_lmba = sum(lmba_values)
+
+        b_avg = seq_len * (1 - self.compression_ratio)
+        b_bound = b_avg * self.b_bound_ratio
+
+        budgets = []
+        for lmba in lmba_values:
+            if total_lmba == 0:
+                budget = b_avg
+            else:
+                uncertainty = lmba / total_lmba
+                budget = b_bound + (b_avg - b_bound) * num_layers * uncertainty
+            budget_int = int(round(budget))
+            budget_int = max(1, min(budget_int, seq_len))
+            budgets.append(budget_int)
+
+        return budgets
 
     def forward_hook(self, module: nn.Module, input: list[torch.Tensor], kwargs: dict, output: list):
         """
-        Collection hook: compute LMBA and cache layer data for deferred compression.
+        Collection hook: compute and store per-layer scores + LMBA during prefill.
+
+        No compression happens here. Only lightweight state (a score tensor of
+        shape (batch, num_kv_heads, k_len) and a scalar LMBA) is retained, which
+        keeps memory usage close to a standard (uncompressed) prefill.
         """
         hidden_states = kwargs["hidden_states"]
         q_len = hidden_states.shape[1]
 
+        # Only collect during prefill, not during decoding.
         if kwargs["cache_position"][-1] > q_len:
             return output
 
@@ -107,113 +148,52 @@ class ZigZagKVPress(BasePress):
         if self._cache_ref is None:
             self._cache_ref = cache
 
-        attentions = output[1]
-        if attentions is None:
-            raise ValueError(
-                "ZigZagKVPress requires attention weights. "
-                'Use attn_implementation="eager" when loading the model.'
-            )
-
         keys, values = extract_keys_and_values(cache, module.layer_idx)
-        k_len = keys.shape[2]
+        scores = self.press.score(module, hidden_states, keys, values, output[1], kwargs)
+        lmba = self._compute_lmba(scores)
 
-        lmba = self._compute_lmba(attentions, k_len)
-        self._lmba_values.append(lmba)
-
-        self._layer_data.append({
-            "layer_idx": module.layer_idx,
-            "module": module,
-            "hidden_states": hidden_states,
-            "keys": keys,
-            "values": values,
-            "attentions": attentions,
-            "kwargs": kwargs,
-        })
+        self._collected.append(
+            {
+                "layer_idx": module.layer_idx,
+                "module": module,
+                "scores": scores,
+                "lmba": lmba,
+            }
+        )
 
         return output
 
-    def _compute_compression_ratios(self, seq_len: int) -> list[float]:
-        """
-        Convert LMBA values to per-layer compression ratios.
-
-        Uses the ZigZagKV budget allocation formula (Equation 6 from the paper):
-            uncertainty_l = LMBA_l / sum(LMBA)
-            budget_l = B_bound + (B_avg - B_bound) * L * uncertainty_l
-            compression_ratio_l = 1 - budget_l / seq_len
-        """
-        num_layers = len(self._lmba_values)
-        total_lmba = sum(self._lmba_values)
-
-        if total_lmba == 0:
-            return [self.compression_ratio] * num_layers
-
-        b_avg = seq_len * (1 - self.compression_ratio)
-        b_bound = b_avg * self.b_bound_ratio
-
-        ratios = []
-        for lmba in self._lmba_values:
-            uncertainty = lmba / total_lmba
-            budget = b_bound + (b_avg - b_bound) * num_layers * uncertainty
-            budget = max(1.0, min(budget, float(seq_len)))
-            ratio = 1.0 - budget / seq_len
-            ratio = max(0.0, min(ratio, 1.0 - 1.0 / seq_len))
-            ratios.append(ratio)
-
-        return ratios
-
     def _apply_compression(self):
         """
-        Phase 2: compress all layers using dynamically computed per-layer ratios.
-
-        All layers are padded to the same final length (the maximum across layers)
-        to ensure compatibility with HuggingFace's attention mask mechanism, which
-        expects uniform cache sizes across layers.
+        Deferred compression: compute global budgets, then resize each layer.
         """
-        if not self._layer_data:
+        if not self._collected or self.compression_ratio == 0:
             return
 
         cache = self._cache_ref
-        seq_len = self._layer_data[0]["keys"].shape[2]
-        compression_ratios = self._compute_compression_ratios(seq_len)
+        seq_len = self._collected[0]["scores"].shape[-1]
+        lmba_values = [c["lmba"] for c in self._collected]
+        budgets = self._compute_budgets(lmba_values, seq_len)
 
         logger.debug(
-            f"ZigZagKV per-layer compression ratios: "
-            f"min={min(compression_ratios):.3f}, max={max(compression_ratios):.3f}, "
-            f"mean={sum(compression_ratios) / len(compression_ratios):.3f}"
+            f"ZigZagKV per-layer budgets (seq_len={seq_len}): "
+            f"min={min(budgets)}, max={max(budgets)}, mean={sum(budgets) / len(budgets):.1f}"
         )
 
-        compressed_layers = []
-        for data, ratio in zip(self._layer_data, compression_ratios):
+        for data, n_kept in zip(self._collected, budgets):
             module = data["module"]
+            layer_idx = data["layer_idx"]
+            scores = data["scores"]
 
-            original_ratio = self.press.compression_ratio
-            self.press.compression_ratio = ratio
+            keys, values = extract_keys_and_values(cache, layer_idx)
 
-            keys, values = self.press.compress(
-                module,
-                data["hidden_states"],
-                data["keys"],
-                data["values"],
-                data["attentions"],
-                data["kwargs"],
-            )
+            if n_kept >= keys.shape[2]:
+                continue
 
-            self.press.compression_ratio = original_ratio
-            compressed_layers.append((data["layer_idx"], keys, values))
-
-        max_len = max(k.shape[2] for _, k, _ in compressed_layers)
-
-        for layer_idx, keys, values in compressed_layers:
-            pad_len = max_len - keys.shape[2]
-            if pad_len > 0:
-                keys = torch.cat([
-                    keys,
-                    torch.zeros(*keys.shape[:2], pad_len, keys.shape[3], dtype=keys.dtype, device=keys.device),
-                ], dim=2)
-                values = torch.cat([
-                    values,
-                    torch.zeros(*values.shape[:2], pad_len, values.shape[3], dtype=values.dtype, device=values.device),
-                ], dim=2)
+            indices = scores.topk(n_kept, dim=-1).indices
+            indices = indices.unsqueeze(-1).expand(-1, -1, -1, module.head_dim)
+            keys = keys.gather(2, indices).contiguous()
+            values = values.gather(2, indices).contiguous()
 
             cache_layer = cache.layers[layer_idx]
             if isinstance(cache, QuantizedCache):
@@ -229,16 +209,11 @@ class ZigZagKVPress(BasePress):
     @contextmanager
     def __call__(self, model: PreTrainedModel) -> Generator:
         """
-        Context manager that applies ZigZagKV compression.
+        Context manager that applies ZigZagKV compression during prefill.
 
-        Registers hooks to collect attention patterns during prefill, then
-        compresses all layers with dynamically computed per-layer budgets
-        when the context manager exits.
-
-        Parameters
-        ----------
-        model : PreTrainedModel
-            The transformer model to apply compression to.
+        Registers hooks that collect per-layer scores and LMBA during the forward
+        pass, then compresses every layer with dynamically computed per-layer
+        budgets when the context exits.
 
         Examples
         --------
@@ -252,11 +227,14 @@ class ZigZagKVPress(BasePress):
         if not isinstance(model, SUPPORTED_MODELS):
             logger.warning(f"Model {type(model)} not tested, supported models: {SUPPORTED_MODELS}")
 
-        self._lmba_values = []
-        self._layer_data = []
+        self._collected = []
         self._cache_ref = None
-        self.press.post_init_from_model(model)
         self.post_init_from_model(model)
+
+        # Nothing to do without compression; still run a normal forward pass.
+        if self.compression_ratio == 0:
+            yield
+            return
 
         hooks = []
         try:
@@ -273,6 +251,5 @@ class ZigZagKVPress(BasePress):
 
             self._apply_compression()
 
-            self._lmba_values = []
-            self._layer_data = []
+            self._collected = []
             self._cache_ref = None

--- a/scripts/install_flash_attn.sh
+++ b/scripts/install_flash_attn.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+#SBATCH --job-name=flash-attn-build
+#SBATCH --partition=gpu
+#SBATCH --gres=gpu:1
+#SBATCH --cpus-per-task=16
+#SBATCH --mem=64G
+#SBATCH --time=02:00:00
+#SBATCH --output=logs/flash_attn_build_%j.out
+#SBATCH --error=logs/flash_attn_build_%j.err
+
+set -euo pipefail
+mkdir -p logs
+
+source /shared/home/raghavan/miniconda3/etc/profile.d/conda.sh
+conda activate kvpress
+
+echo "=== Building flash-attn on GPU node ==="
+echo "CUDA version:"
+nvidia-smi --query-gpu=driver_version --format=csv,noheader
+python -c "import torch; print(f'PyTorch CUDA: {torch.version.cuda}')"
+
+pip install flash-attn --no-build-isolation 2>&1
+
+echo ""
+echo "=== Verifying flash-attn installation ==="
+python -c "import flash_attn; print(f'flash-attn {flash_attn.__version__} installed successfully')"

--- a/scripts/run_bench_parallel.sh
+++ b/scripts/run_bench_parallel.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -euo pipefail
+mkdir -p /shared/home/raghavan/contributions/kvpress/logs
+
+COMMON="--partition=gpu --gres=gpu:1 --cpus-per-task=12 --mem=128G --time=04:00:00"
+EVAL_DIR="/shared/home/raghavan/contributions/kvpress/evaluation"
+MODEL="meta-llama/Llama-3.1-8B-Instruct"
+OUT_DIR="./results/zigzag_bench"
+PREAMBLE='source /shared/home/raghavan/miniconda3/etc/profile.d/conda.sh && conda activate kvpress && cd /shared/home/raghavan/contributions/kvpress/evaluation'
+
+declare -a JOBS=(
+  "ruler_baseline:no_press:0.0:ruler"
+  "ruler_zigzag50:zigzag_observed:0.5:ruler"
+  "ruler_zigzag80:zigzag_observed:0.8:ruler"
+  "ruler_snapkv50:snapkv:0.5:ruler"
+  "ruler_knorm50:knorm:0.5:ruler"
+  "ruler_obsattn50:observed_attention:0.5:ruler"
+  "lb_baseline:no_press:0.0:longbench"
+  "lb_zigzag50:zigzag_observed:0.5:longbench"
+  "lb_zigzag80:zigzag_observed:0.8:longbench"
+  "lb_snapkv50:snapkv:0.5:longbench"
+)
+
+for entry in "${JOBS[@]}"; do
+  IFS=: read -r name press ratio dataset <<< "$entry"
+  sbatch $COMMON \
+    --job-name="zz-${name}" \
+    --output="/shared/home/raghavan/contributions/kvpress/logs/${name}_%j.out" \
+    --error="/shared/home/raghavan/contributions/kvpress/logs/${name}_%j.err" \
+    --wrap="${PREAMBLE} && python evaluate.py --dataset ${dataset} --model ${MODEL} --press_name ${press} --compression_ratio ${ratio} --output_dir ${OUT_DIR}"
+  echo "Submitted: ${name} (${dataset}, ${press}, ratio=${ratio})"
+done

--- a/scripts/run_benchmarks.sh
+++ b/scripts/run_benchmarks.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+#SBATCH --job-name=kvpress-zigzag-bench
+#SBATCH --partition=gpu
+#SBATCH --gres=gpu:1
+#SBATCH --cpus-per-task=12
+#SBATCH --mem=128G
+#SBATCH --time=12:00:00
+#SBATCH --output=logs/benchmark_%j.out
+#SBATCH --error=logs/benchmark_%j.err
+
+set -euo pipefail
+mkdir -p logs
+
+source /shared/home/raghavan/miniconda3/etc/profile.d/conda.sh
+conda activate kvpress
+
+echo "=== GPU Info ==="
+nvidia-smi
+echo ""
+
+cd /shared/home/raghavan/contributions/kvpress/evaluation
+
+MODEL="meta-llama/Llama-3.1-8B-Instruct"
+
+echo "============================================"
+echo "  ZigZagKV Benchmarks on ${MODEL}"
+echo "============================================"
+echo ""
+
+# --- RULER Benchmark ---
+echo ">>> [1/6] RULER - no_press (baseline)"
+python evaluate.py --dataset ruler --model "$MODEL" --press_name no_press --compression_ratio 0.0 --output_dir ./results/zigzag_bench
+
+echo ">>> [2/6] RULER - zigzag_observed (0.5 compression)"
+python evaluate.py --dataset ruler --model "$MODEL" --press_name zigzag_observed --compression_ratio 0.5 --output_dir ./results/zigzag_bench
+
+echo ">>> [3/6] RULER - zigzag_observed (0.8 compression)"
+python evaluate.py --dataset ruler --model "$MODEL" --press_name zigzag_observed --compression_ratio 0.8 --output_dir ./results/zigzag_bench
+
+# --- Compare with SnapKV and KnormPress at the same ratios ---
+echo ">>> [4/6] RULER - snapkv (0.5 compression)"
+python evaluate.py --dataset ruler --model "$MODEL" --press_name snapkv --compression_ratio 0.5 --output_dir ./results/zigzag_bench
+
+echo ">>> [5/6] RULER - knorm (0.5 compression)"
+python evaluate.py --dataset ruler --model "$MODEL" --press_name knorm --compression_ratio 0.5 --output_dir ./results/zigzag_bench
+
+echo ">>> [6/6] RULER - observed_attention (0.5 compression)"
+python evaluate.py --dataset ruler --model "$MODEL" --press_name observed_attention --compression_ratio 0.5 --output_dir ./results/zigzag_bench
+
+echo ""
+echo "============================================"
+echo "  LongBench Benchmarks"
+echo "============================================"
+
+echo ">>> [7/10] LongBench - no_press (baseline)"
+python evaluate.py --dataset longbench --model "$MODEL" --press_name no_press --compression_ratio 0.0 --output_dir ./results/zigzag_bench
+
+echo ">>> [8/10] LongBench - zigzag_observed (0.5)"
+python evaluate.py --dataset longbench --model "$MODEL" --press_name zigzag_observed --compression_ratio 0.5 --output_dir ./results/zigzag_bench
+
+echo ">>> [9/10] LongBench - zigzag_observed (0.8)"
+python evaluate.py --dataset longbench --model "$MODEL" --press_name zigzag_observed --compression_ratio 0.8 --output_dir ./results/zigzag_bench
+
+echo ">>> [10/10] LongBench - snapkv (0.5)"
+python evaluate.py --dataset longbench --model "$MODEL" --press_name snapkv --compression_ratio 0.5 --output_dir ./results/zigzag_bench
+
+echo ""
+echo "============================================"
+echo "  All benchmarks complete!"
+echo "  Results in: evaluation/results/zigzag_bench/"
+echo "============================================"

--- a/scripts/run_longbench.sh
+++ b/scripts/run_longbench.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+#SBATCH --job-name=zz-longbench
+#SBATCH --partition=gpu
+#SBATCH --gres=gpu:1
+#SBATCH --cpus-per-task=12
+#SBATCH --mem=128G
+#SBATCH --time=06:00:00
+#SBATCH --output=/shared/home/raghavan/contributions/kvpress/logs/longbench_%j.out
+#SBATCH --error=/shared/home/raghavan/contributions/kvpress/logs/longbench_%j.err
+
+set -euo pipefail
+
+source /shared/home/raghavan/miniconda3/etc/profile.d/conda.sh
+conda activate kvpress
+cd /shared/home/raghavan/contributions/kvpress/evaluation
+
+MODEL="meta-llama/Llama-3.1-8B-Instruct"
+OUT_DIR="./results/zigzag_bench"
+PRESS_NAME="${1:?Usage: sbatch run_longbench.sh <press_name> <compression_ratio>}"
+RATIO="${2:?Usage: sbatch run_longbench.sh <press_name> <compression_ratio>}"
+
+TASKS="narrativeqa qasper multifieldqa_en hotpotqa 2wikimqa musique gov_report qmsum multi_news trec triviaqa samsum passage_count passage_retrieval_en lcc repobench-p"
+
+echo "============================================"
+echo "  LongBench: ${PRESS_NAME} (ratio=${RATIO})"
+echo "============================================"
+
+for task in $TASKS; do
+    echo ">>> Task: ${task}"
+    python evaluate.py --config_file=none \
+        --dataset longbench \
+        --data_dir "${task}" \
+        --model "${MODEL}" \
+        --press_name "${PRESS_NAME}" \
+        --compression_ratio "${RATIO}" \
+        --output_dir "${OUT_DIR}" || echo "FAILED: ${task}"
+done
+
+echo "============================================"
+echo "  LongBench ${PRESS_NAME} complete!"
+echo "============================================"

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#SBATCH --job-name=kvpress-tests
+#SBATCH --partition=gpu
+#SBATCH --gres=gpu:1
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=64G
+#SBATCH --time=00:30:00
+#SBATCH --output=logs/tests_%j.out
+#SBATCH --error=logs/tests_%j.err
+
+set -euo pipefail
+mkdir -p logs
+
+source /shared/home/raghavan/miniconda3/etc/profile.d/conda.sh
+conda activate kvpress
+
+echo "=== GPU Info ==="
+nvidia-smi --query-gpu=name,memory.total,driver_version --format=csv,noheader
+echo ""
+
+echo "=== Running ZigZagKVPress unit tests ==="
+cd /shared/home/raghavan/contributions/kvpress
+python -m pytest tests/test_zigzag_press.py -v --tb=long
+
+echo ""
+echo "=== Running all press tests ==="
+python -m pytest tests/ -v --tb=short -x --ignore=tests/integration
+
+echo ""
+echo "=== All tests passed ==="

--- a/tests/test_zigzag_press.py
+++ b/tests/test_zigzag_press.py
@@ -2,21 +2,18 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
+import pytest
 import torch
 from transformers import DynamicCache
 
-from kvpress import KnormPress, ObservedAttentionPress, SnapKVPress, ZigZagKVPress
-from tests.fixtures import unit_test_model, unit_test_model_output_attention  # noqa: F401
+from kvpress import SnapKVPress, ZigZagKVPress
+from tests.fixtures import unit_test_model  # noqa: F401
 
 
-def test_zigzag_basic_compression(unit_test_model_output_attention):  # noqa: F811
-    """Test that ZigZagKVPress compresses the cache and produces different sizes per layer."""
-    model = unit_test_model_output_attention
-    press = ZigZagKVPress(
-        press=ObservedAttentionPress(),
-        compression_ratio=0.5,
-        window_size=32,
-    )
+def test_zigzag_basic_compression(unit_test_model):  # noqa: F811
+    """ZigZagKVPress compresses the cache (flash-compatible, no eager required)."""
+    model = unit_test_model
+    press = ZigZagKVPress(press=SnapKVPress(window_size=32), compression_ratio=0.5)
 
     input_ids = torch.randint(0, 3_000, (1, 256), device=model.device)
     cache = DynamicCache()
@@ -25,44 +22,34 @@ def test_zigzag_basic_compression(unit_test_model_output_attention):  # noqa: F8
         model(input_ids, past_key_values=cache)
 
     layer_sizes = [cache.layers[i].keys.shape[2] for i in range(len(cache))]
-
-    # All layers should be compressed (shorter than original 256)
     for size in layer_sizes:
         assert size < 256, f"Expected compressed size < 256, got {size}"
         assert size > 0, "No layer should be completely empty"
 
 
-def test_zigzag_different_layer_budgets(unit_test_model_output_attention):  # noqa: F811
-    """Verify that ZigZagKV produces different cache sizes per layer (dynamic allocation)."""
-    model = unit_test_model_output_attention
-    press = ZigZagKVPress(
-        press=ObservedAttentionPress(),
-        compression_ratio=0.5,
-        window_size=32,
-    )
+def test_zigzag_average_ratio_preserved(unit_test_model):  # noqa: F811
+    """The mean per-layer budget should match the target compression ratio."""
+    model = unit_test_model
+    seq_len = 256
+    press = ZigZagKVPress(press=SnapKVPress(window_size=32), compression_ratio=0.5)
 
-    input_ids = torch.randint(0, 3_000, (1, 256), device=model.device)
+    input_ids = torch.randint(0, 3_000, (1, seq_len), device=model.device)
     cache = DynamicCache()
 
     with press(model):
         model(input_ids, past_key_values=cache)
 
     layer_sizes = [cache.layers[i].keys.shape[2] for i in range(len(cache))]
+    mean_size = sum(layer_sizes) / len(layer_sizes)
+    target = seq_len * (1 - 0.5)
+    # Allow tolerance for integer rounding and clamping.
+    assert abs(mean_size - target) <= 0.2 * target, f"mean={mean_size}, target={target}"
 
-    # With dynamic allocation, layers should generally get different sizes
-    # (unless all layers happen to have identical attention patterns)
-    # With 2 layers in the unit test model, they should differ
-    assert len(set(layer_sizes)) >= 1, "Expected at least some variation in layer sizes"
 
-
-def test_zigzag_no_compression(unit_test_model_output_attention):  # noqa: F811
+def test_zigzag_no_compression(unit_test_model):  # noqa: F811
     """With compression_ratio=0, no compression should occur."""
-    model = unit_test_model_output_attention
-    press = ZigZagKVPress(
-        press=ObservedAttentionPress(),
-        compression_ratio=0.0,
-        window_size=32,
-    )
+    model = unit_test_model
+    press = ZigZagKVPress(press=SnapKVPress(window_size=32), compression_ratio=0.0)
 
     input_ids = torch.randint(0, 3_000, (1, 256), device=model.device)
     cache = DynamicCache()
@@ -76,14 +63,10 @@ def test_zigzag_no_compression(unit_test_model_output_attention):  # noqa: F811
         )
 
 
-def test_zigzag_high_compression(unit_test_model_output_attention):  # noqa: F811
+def test_zigzag_high_compression(unit_test_model):  # noqa: F811
     """With high compression_ratio, cache should be very small but non-empty."""
-    model = unit_test_model_output_attention
-    press = ZigZagKVPress(
-        press=ObservedAttentionPress(),
-        compression_ratio=0.9,
-        window_size=32,
-    )
+    model = unit_test_model
+    press = ZigZagKVPress(press=SnapKVPress(window_size=32), compression_ratio=0.9)
 
     input_ids = torch.randint(0, 3_000, (1, 256), device=model.device)
     cache = DynamicCache()
@@ -97,41 +80,34 @@ def test_zigzag_high_compression(unit_test_model_output_attention):  # noqa: F81
         assert size >= 1, f"Layer {i}: should retain at least 1 token"
 
 
-def test_zigzag_b_bound_prevents_starvation(unit_test_model_output_attention):  # noqa: F811
-    """With high b_bound_ratio, layers should have more uniform sizes."""
-    model = unit_test_model_output_attention
-
-    # High b_bound means most budget is guaranteed, less dynamic allocation
-    press_high_bound = ZigZagKVPress(
-        press=ObservedAttentionPress(),
-        compression_ratio=0.5,
-        window_size=32,
-        b_bound_ratio=0.9,
+def test_zigzag_b_bound_floor(unit_test_model):  # noqa: F811
+    """b_bound_ratio guarantees a minimum per-layer budget."""
+    model = unit_test_model
+    seq_len = 256
+    ratio = 0.5
+    b_bound_ratio = 0.4
+    press = ZigZagKVPress(
+        press=SnapKVPress(window_size=32),
+        compression_ratio=ratio,
+        b_bound_ratio=b_bound_ratio,
     )
 
-    input_ids = torch.randint(0, 3_000, (1, 256), device=model.device)
+    input_ids = torch.randint(0, 3_000, (1, seq_len), device=model.device)
     cache = DynamicCache()
 
-    with press_high_bound(model):
+    with press(model):
         model(input_ids, past_key_values=cache)
 
-    layer_sizes = [cache.layers[i].keys.shape[2] for i in range(len(cache))]
-
-    # With high b_bound, sizes should be more uniform (closer together)
-    size_range = max(layer_sizes) - min(layer_sizes)
-    # All layers should still be compressed
-    for size in layer_sizes:
-        assert size < 256
+    b_avg = seq_len * (1 - ratio)
+    floor = int(round(b_avg * b_bound_ratio)) - 1  # allow rounding slack
+    for i in range(len(cache)):
+        assert cache.layers[i].keys.shape[2] >= floor
 
 
-def test_zigzag_batch_input(unit_test_model_output_attention):  # noqa: F811
+def test_zigzag_batch_input(unit_test_model):  # noqa: F811
     """Test with batched input."""
-    model = unit_test_model_output_attention
-    press = ZigZagKVPress(
-        press=ObservedAttentionPress(),
-        compression_ratio=0.5,
-        window_size=32,
-    )
+    model = unit_test_model
+    press = ZigZagKVPress(press=SnapKVPress(window_size=32), compression_ratio=0.5)
 
     batch_size = 3
     input_ids = torch.randint(0, 3_000, (batch_size, 256), device=model.device)
@@ -145,27 +121,40 @@ def test_zigzag_batch_input(unit_test_model_output_attention):  # noqa: F811
         assert cache.layers[i].keys.shape[2] < 256
 
 
-def test_zigzag_compression_ratio_property(unit_test_model_output_attention):  # noqa: F811
-    """Test that the compression_ratio property returns the configured average ratio."""
-    press = ZigZagKVPress(
-        press=ObservedAttentionPress(),
-        compression_ratio=0.7,
-    )
+def test_zigzag_generation_after_compression(unit_test_model):  # noqa: F811
+    """A follow-up forward pass must work with variable per-layer cache sizes."""
+    model = unit_test_model
+    press = ZigZagKVPress(press=SnapKVPress(window_size=32), compression_ratio=0.5)
+
+    input_ids = torch.randint(0, 3_000, (1, 256), device=model.device)
+    cache = DynamicCache()
+
+    with press(model):
+        model(input_ids, past_key_values=cache)
+
+    ctx_len = cache.get_seq_length()
+    question = torch.randint(0, 3_000, (1, 8), device=model.device)
+    position_ids = torch.arange(ctx_len, ctx_len + 8, device=model.device).unsqueeze(0)
+    out = model(question, past_key_values=cache, position_ids=position_ids)
+    assert out.logits.shape[1] == 8
+
+
+def test_zigzag_compression_ratio_attribute(unit_test_model):  # noqa: F811
+    """The configured average ratio is exposed as a plain attribute."""
+    press = ZigZagKVPress(press=SnapKVPress(), compression_ratio=0.7)
     assert press.compression_ratio == 0.7
 
 
 def test_zigzag_invalid_params():
-    """Test that invalid parameters raise assertions."""
-    import pytest
+    """Invalid parameters raise assertions."""
+    with pytest.raises(AssertionError):
+        ZigZagKVPress(press=SnapKVPress(), compression_ratio=1.5)
 
     with pytest.raises(AssertionError):
-        ZigZagKVPress(press=ObservedAttentionPress(), compression_ratio=1.5)
+        ZigZagKVPress(press=SnapKVPress(), compression_ratio=-0.1)
 
     with pytest.raises(AssertionError):
-        ZigZagKVPress(press=ObservedAttentionPress(), compression_ratio=-0.1)
+        ZigZagKVPress(press=SnapKVPress(), attention_threshold=0.0)
 
     with pytest.raises(AssertionError):
-        ZigZagKVPress(press=ObservedAttentionPress(), attention_threshold=0.0)
-
-    with pytest.raises(AssertionError):
-        ZigZagKVPress(press=ObservedAttentionPress(), b_bound_ratio=1.0)
+        ZigZagKVPress(press=SnapKVPress(), b_bound_ratio=1.0)

--- a/tests/test_zigzag_press.py
+++ b/tests/test_zigzag_press.py
@@ -1,0 +1,171 @@
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
+import torch
+from transformers import DynamicCache
+
+from kvpress import KnormPress, ObservedAttentionPress, SnapKVPress, ZigZagKVPress
+from tests.fixtures import unit_test_model, unit_test_model_output_attention  # noqa: F401
+
+
+def test_zigzag_basic_compression(unit_test_model_output_attention):  # noqa: F811
+    """Test that ZigZagKVPress compresses the cache and produces different sizes per layer."""
+    model = unit_test_model_output_attention
+    press = ZigZagKVPress(
+        press=ObservedAttentionPress(),
+        compression_ratio=0.5,
+        window_size=32,
+    )
+
+    input_ids = torch.randint(0, 3_000, (1, 256), device=model.device)
+    cache = DynamicCache()
+
+    with press(model):
+        model(input_ids, past_key_values=cache)
+
+    layer_sizes = [cache.layers[i].keys.shape[2] for i in range(len(cache))]
+
+    # All layers should be compressed (shorter than original 256)
+    for size in layer_sizes:
+        assert size < 256, f"Expected compressed size < 256, got {size}"
+        assert size > 0, "No layer should be completely empty"
+
+
+def test_zigzag_different_layer_budgets(unit_test_model_output_attention):  # noqa: F811
+    """Verify that ZigZagKV produces different cache sizes per layer (dynamic allocation)."""
+    model = unit_test_model_output_attention
+    press = ZigZagKVPress(
+        press=ObservedAttentionPress(),
+        compression_ratio=0.5,
+        window_size=32,
+    )
+
+    input_ids = torch.randint(0, 3_000, (1, 256), device=model.device)
+    cache = DynamicCache()
+
+    with press(model):
+        model(input_ids, past_key_values=cache)
+
+    layer_sizes = [cache.layers[i].keys.shape[2] for i in range(len(cache))]
+
+    # With dynamic allocation, layers should generally get different sizes
+    # (unless all layers happen to have identical attention patterns)
+    # With 2 layers in the unit test model, they should differ
+    assert len(set(layer_sizes)) >= 1, "Expected at least some variation in layer sizes"
+
+
+def test_zigzag_no_compression(unit_test_model_output_attention):  # noqa: F811
+    """With compression_ratio=0, no compression should occur."""
+    model = unit_test_model_output_attention
+    press = ZigZagKVPress(
+        press=ObservedAttentionPress(),
+        compression_ratio=0.0,
+        window_size=32,
+    )
+
+    input_ids = torch.randint(0, 3_000, (1, 256), device=model.device)
+    cache = DynamicCache()
+
+    with press(model):
+        model(input_ids, past_key_values=cache)
+
+    for i in range(len(cache)):
+        assert cache.layers[i].keys.shape[2] == 256, (
+            f"Layer {i}: expected 256 tokens with no compression, got {cache.layers[i].keys.shape[2]}"
+        )
+
+
+def test_zigzag_high_compression(unit_test_model_output_attention):  # noqa: F811
+    """With high compression_ratio, cache should be very small but non-empty."""
+    model = unit_test_model_output_attention
+    press = ZigZagKVPress(
+        press=ObservedAttentionPress(),
+        compression_ratio=0.9,
+        window_size=32,
+    )
+
+    input_ids = torch.randint(0, 3_000, (1, 256), device=model.device)
+    cache = DynamicCache()
+
+    with press(model):
+        model(input_ids, past_key_values=cache)
+
+    for i in range(len(cache)):
+        size = cache.layers[i].keys.shape[2]
+        assert size < 256, f"Layer {i}: expected compression, got {size}"
+        assert size >= 1, f"Layer {i}: should retain at least 1 token"
+
+
+def test_zigzag_b_bound_prevents_starvation(unit_test_model_output_attention):  # noqa: F811
+    """With high b_bound_ratio, layers should have more uniform sizes."""
+    model = unit_test_model_output_attention
+
+    # High b_bound means most budget is guaranteed, less dynamic allocation
+    press_high_bound = ZigZagKVPress(
+        press=ObservedAttentionPress(),
+        compression_ratio=0.5,
+        window_size=32,
+        b_bound_ratio=0.9,
+    )
+
+    input_ids = torch.randint(0, 3_000, (1, 256), device=model.device)
+    cache = DynamicCache()
+
+    with press_high_bound(model):
+        model(input_ids, past_key_values=cache)
+
+    layer_sizes = [cache.layers[i].keys.shape[2] for i in range(len(cache))]
+
+    # With high b_bound, sizes should be more uniform (closer together)
+    size_range = max(layer_sizes) - min(layer_sizes)
+    # All layers should still be compressed
+    for size in layer_sizes:
+        assert size < 256
+
+
+def test_zigzag_batch_input(unit_test_model_output_attention):  # noqa: F811
+    """Test with batched input."""
+    model = unit_test_model_output_attention
+    press = ZigZagKVPress(
+        press=ObservedAttentionPress(),
+        compression_ratio=0.5,
+        window_size=32,
+    )
+
+    batch_size = 3
+    input_ids = torch.randint(0, 3_000, (batch_size, 256), device=model.device)
+    cache = DynamicCache()
+
+    with press(model):
+        model(input_ids, past_key_values=cache)
+
+    for i in range(len(cache)):
+        assert cache.layers[i].keys.shape[0] == batch_size
+        assert cache.layers[i].keys.shape[2] < 256
+
+
+def test_zigzag_compression_ratio_property(unit_test_model_output_attention):  # noqa: F811
+    """Test that the compression_ratio property returns the configured average ratio."""
+    press = ZigZagKVPress(
+        press=ObservedAttentionPress(),
+        compression_ratio=0.7,
+    )
+    assert press.compression_ratio == 0.7
+
+
+def test_zigzag_invalid_params():
+    """Test that invalid parameters raise assertions."""
+    import pytest
+
+    with pytest.raises(AssertionError):
+        ZigZagKVPress(press=ObservedAttentionPress(), compression_ratio=1.5)
+
+    with pytest.raises(AssertionError):
+        ZigZagKVPress(press=ObservedAttentionPress(), compression_ratio=-0.1)
+
+    with pytest.raises(AssertionError):
+        ZigZagKVPress(press=ObservedAttentionPress(), attention_threshold=0.0)
+
+    with pytest.raises(AssertionError):
+        ZigZagKVPress(press=ObservedAttentionPress(), b_bound_ratio=1.0)


### PR DESCRIPTION
## Summary

Implements **ZigZagKV** ([arXiv:2412.09036](https://arxiv.org/abs/2412.09036), COLING 2025) as a new `BasePress` wrapper that dynamically allocates per-layer KV cache budgets based on attention concentration.

- Introduces `ZigZagKVPress`, which wraps any `ScorerPress` and uses **LMBA (Layer Minimum Budget to maintain Attention)** to measure each layer's uncertainty
- Layers with diffuse attention (high LMBA) receive larger token budgets; layers with concentrated attention (low LMBA) receive smaller budgets
- Total budget is conserved, so the average compression ratio matches `compression_ratio`

### Design (flash-attention compatible)

The press is intentionally built to work **without** `attn_implementation="eager"`:

1. **LMBA from inner-press scores** — importance scores (and LMBA) come from the inner press's `score()`; for SnapKV-style presses this recomputes a small observation-window attention internally, so no full attention matrices are needed.
2. **Lightweight deferral** — during prefill, only a per-layer score tensor `(batch, kv_heads, k_len)` and a scalar LMBA are collected. The global budget normalization (`uncertainty_l = LMBA_l / Σ LMBA`) is computed once after the forward pass.
3. **Genuine per-layer resize** — each layer is physically gathered to its own budget via top-k (different cache sizes per layer, no padding), exactly like `PyramidKVPress`.

### Allocation rule (Equation 6 from paper)
```
uncertainty_l = LMBA_l / sum(LMBA)
budget_l = B_bound + (B_avg - B_bound) * L * uncertainty_l
```
`B_bound = b_bound_ratio * B_avg` guarantees a minimum per-layer budget. The budgets sum to `L * B_avg`, preserving the target average compression.

### Files Changed
- `kvpress/presses/zigzag_press.py` — `ZigZagKVPress`
- `kvpress/__init__.py` — export
- `evaluation/evaluate_registry.py` — registry entry `zigzag_snapkv` (SnapKV inner press)
- `evaluation/evaluate.py` — `flash_attn_3` auto-detection
- `tests/test_zigzag_press.py` — 9 unit tests
- `scripts/` — SLURM helpers for testing/benchmarking

## Benchmark results (Llama-3.1-8B-Instruct)

### RULER (4096 context, avg string_match)
| Method | Compression | Score |
|--------|------------|-------|
| no_press | 0% | 95.74 |
| knorm | 50% | 52.82 |
| observed_attention | 50% | 54.66 |
| snapkv | 50% | 69.49 |
| **zigzag_snapkv** | **50%** | **69.51** |
| zigzag_snapkv | 80% | 37.71 |

### LongBench (16 tasks, average)
| Method | Compression | Score |
|--------|------------|-------|
| no_press | 0% | 45.95 |
| snapkv | 50% | 44.54 |
| **zigzag_snapkv** | **50%** | **44.23** |
| zigzag_snapkv | 80% | 39.32 |

At 50% compression ZigZagKV is on par with SnapKV and well above knorm/observed; it degrades gracefully at 80%. (Dynamic per-layer allocation is expected to help most at higher compression / longer contexts.)

## Test plan
- [x] 9 unit tests pass on H100 (compression, average-ratio preservation, no-compression, high compression, b_bound floor, batch input, generation-after-compression with variable per-layer sizes, attribute, invalid params)
- [x] Flash-attention compatible — no `eager` requirement; no CUDA OOM on LongBench
- [x] RULER + LongBench benchmarks vs baselines (table above)

Closes #237