### PR TITLE
Fix: rerotation with multi-gpus

### DIFF
--- a/kvpress/presses/key_rerotation_press.py
+++ b/kvpress/presses/key_rerotation_press.py
@@ -71,9 +71,11 @@ class KeyRerotationPress(BasePress):
             ``(bsz, num_key_value_heads, n_kept, d)``, matching ``dtype``/``device`` of ``x``.
         """
         bsz, num_key_value_heads, n_kept = selected_positions.shape
-        device = selected_positions.device
+        device = x.device
         device_type = x.device.type
         dtype = x.dtype
+        selected_positions = selected_positions.to(device)
+        inv_freq = inv_freq.to(device)
         # Original positional indices
         idx = torch.arange(0, n_kept, device=device)  # (n_kept,)
         idx = idx.unsqueeze(0)  # (1, n_kept)


### PR DESCRIPTION
Fixes #240

This PR fixes a device mismatch in key re-rotation when models are split across multiple GPUs with `device_map="auto"`.

`KeyRerotationPress._rerotate_cos_sin()` could receive `x`, `selected_positions`, and `inv_freq` on different CUDA devices. This caused re-rotation to fail with errors like:

```text
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cuda:1!
```

The fix uses `x.device` as the canonical device inside `_rerotate_cos_sin()` and moves `selected_positions` and `inv_freq` there before computing the rotary frequencies.

This fixes `FinchPress` and should also apply to other presses using `KeyRerotationPress.rerotate_keys()`.

Tested locally with `FinchPress` and `meta-llama/Llama-3.1-8B-Instruct` using `device_map="auto"` on a multi-GPU setup.

## Checklist

Before submitting a PR, please make sure:

- [ ] Tests are working (`make test`)
- [x] Code is formatted correctly (`make style`, on errors try fix with `make format`)
- [x] Copyright header is included
- [x] All commits are signed-off  using `git commit -s`
- [ ] (new press) `mypress_press.py` is in the `presses` directory
- [ ] (new press) `MyPress` is in `__init__.py` 
- [ ] (new press) `README.md` is updated with a 1 liner about the new press in the Available presses section
- [ ] (new press) New press is in the `default_presses` list in `tests/default_presses.py`
- [ ] (new press) A docstring is provided that follows the same structure as the existing ones
