### PR TITLE
Fix cache position phase detection 🤖🤖🤖

### DIFF
--- a/kvpress/presses/base_press.py
+++ b/kvpress/presses/base_press.py
@@ -34,6 +34,12 @@ SUPPORTED_MODELS = (
 )
 
 
+def is_prefilling(cache_position: torch.Tensor, q_len: int) -> bool:
+    """Return whether the current forward pass is the initial prefill."""
+    prefilling = cache_position[-1] + 1 == q_len
+    return bool(prefilling.item() if isinstance(prefilling, torch.Tensor) else prefilling)
+
+
 @dataclass
 class BasePress:
     """
@@ -136,7 +142,7 @@ class BasePress:
         q_len = hidden_states.shape[1]
 
         # Don't compress after pre-filling
-        if kwargs["cache_position"][-1] > q_len:
+        if not is_prefilling(kwargs["cache_position"], q_len):
             return output
 
         keys, values = extract_keys_and_values(cache, module.layer_idx)

--- a/kvpress/presses/cam_press.py
+++ b/kvpress/presses/cam_press.py
@@ -13,6 +13,7 @@ from transformers import QuantizedCache
 from transformers.models.llama.modeling_llama import repeat_kv, rotate_half
 
 from kvpress.presses.adakv_press import AdaKVPress
+from kvpress.presses.base_press import is_prefilling
 from kvpress.presses.decoding_press import DecodingPress
 from kvpress.presses.scorer_press import ScorerPress
 from kvpress.utils import extract_keys_and_values, get_prerope_query_states
@@ -238,7 +239,7 @@ class CAMPress(DecodingPress):
         layer_idx = int(module.layer_idx)
 
         # Only operate during decoding
-        if kwargs["cache_position"][-1] <= q_len:
+        if is_prefilling(kwargs["cache_position"], q_len):
             # Entering prefill for a (potentially new) sequence — drop any per-layer
             # state left over from a previous sequence so that subsequent decoding
             # steps don't try to `+=` against a stale-shaped running attention sum.

--- a/kvpress/presses/decoding_press.py
+++ b/kvpress/presses/decoding_press.py
@@ -12,7 +12,7 @@ from transformers import PreTrainedModel
 from transformers.cache_utils import QuantizedCache
 
 from kvpress.presses.adakv_press import AdaKVPress
-from kvpress.presses.base_press import BasePress
+from kvpress.presses.base_press import BasePress, is_prefilling
 from kvpress.presses.scorer_press import ScorerPress
 from kvpress.utils import extract_keys_and_values
 
@@ -126,7 +126,7 @@ class DecodingPress(BasePress):
         layer_idx = module.layer_idx
 
         # Only operate during decoding phase (after prefilling)
-        if kwargs["cache_position"][-1] <= q_len:
+        if is_prefilling(kwargs["cache_position"], q_len):
             # We're still in prefilling phase, don't do anything
             return output
         # print(f"Adding hidden states to buffer: {hidden_states.shape}")

--- a/kvpress/presses/dms_press.py
+++ b/kvpress/presses/dms_press.py
@@ -7,7 +7,7 @@ from typing import Optional
 import torch
 import torch.nn as nn
 
-from kvpress.presses.base_press import BasePress
+from kvpress.presses.base_press import BasePress, is_prefilling
 from kvpress.presses.scorer_press import ScorerPress
 from kvpress.utils import extract_keys_and_values
 
@@ -71,7 +71,7 @@ class DMSPress(BasePress):
         cache = kwargs["past_key_values"]
         q_len = hidden_states.shape[1]
         cache_len = kwargs["cache_position"][-1] + 1
-        prefilling = cache_len == q_len
+        prefilling = is_prefilling(kwargs["cache_position"], q_len)
 
         # Extract layer index as int for type safety
         layer_idx: int = module.layer_idx  # type: ignore[assignment]

--- a/kvpress/presses/fastkvzip_press.py
+++ b/kvpress/presses/fastkvzip_press.py
@@ -15,7 +15,7 @@ from torch import nn
 from transformers import AutoConfig, Gemma3ForConditionalGeneration, PreTrainedModel
 from transformers.models.qwen3.modeling_qwen3 import Qwen3RMSNorm
 
-from kvpress.presses.base_press import SUPPORTED_MODELS, BasePress
+from kvpress.presses.base_press import SUPPORTED_MODELS, BasePress, is_prefilling
 
 logger = logging.getLogger(__name__)
 
@@ -223,7 +223,7 @@ class FastKVzipPress(BasePress):
         q_len = hidden_states.shape[1]
 
         # Don't compress after pre-filling
-        if kwargs["cache_position"][-1] > q_len:
+        if not is_prefilling(kwargs["cache_position"], q_len):
             return output
 
         self._score_fast(module, hidden_states)

--- a/kvpress/presses/prefill_decoding_press.py
+++ b/kvpress/presses/prefill_decoding_press.py
@@ -10,7 +10,7 @@ import torch
 import torch.nn as nn
 from transformers import PreTrainedModel
 
-from kvpress.presses.base_press import BasePress
+from kvpress.presses.base_press import BasePress, is_prefilling
 from kvpress.presses.decoding_press import DecodingPress
 
 logger = logging.getLogger(__name__)
@@ -54,7 +54,7 @@ class PrefillDecodingPress(BasePress):
         q_len = hidden_states.shape[1]
 
         # Determine if we're in prefilling or decoding phase
-        if kwargs["cache_position"][-1] <= q_len and self.prefilling_press is not None:
+        if is_prefilling(kwargs["cache_position"], q_len) and self.prefilling_press is not None:
             return self.prefilling_press.compress(module, hidden_states, keys, values, attentions, kwargs)
         elif self.decoding_press is not None:
             return self.decoding_press.compress(module, hidden_states, keys, values, attentions, kwargs)
@@ -72,7 +72,7 @@ class PrefillDecodingPress(BasePress):
         q_len = hidden_states.shape[1]
 
         # Determine if we're in prefilling or decoding phase
-        if kwargs["cache_position"][-1] <= q_len and self.prefilling_press is not None:
+        if is_prefilling(kwargs["cache_position"], q_len) and self.prefilling_press is not None:
             return self.prefilling_press.forward_hook(module, input, kwargs, output)
         elif self.decoding_press is not None:
             return self.decoding_press.forward_hook(module, input, kwargs, output)


### PR DESCRIPTION
## Summary
- Add a shared `is_prefilling` helper based on zero-based `cache_position` length.
- Use the helper across prefill-only and decoding press hooks so phase detection is consistent.
- Add focused regression coverage for single-token prefill versus single-token decoding.

## Root cause
`cache_position` is zero-based, so checks like `cache_position[-1] <= q_len` missed the `+1` when comparing against `q_len`. That made `cache_position=[1]` with `q_len=1` look like prefill even though it is the first decode step after a one-token prompt.

## Validation
- `uv run pytest tests/test_phase_detection.py`
- `uv run pytest tests/test_decoding_compression.py::test_decoding_press_reuse_across_sequences`
- `uv run flake8 kvpress/presses/base_press.py kvpress/presses/decoding_press.py kvpress/presses/prefill_decoding_press.py kvpress/presses/cam_press.py kvpress/presses/dms_press.py kvpress/presses/fastkvzip_press.py tests/test_phase_detection.py`
- `uv run mypy kvpress/presses/base_press.py kvpress/presses/decoding_press.py kvpress/presses/prefill_decoding_press.py kvpress/presses/cam_press.py kvpress/presses/dms_press.py kvpress/presses/fastkvzip_press.py --check-untyped-defs`
- `make style`
