### PR TITLE
Fix nested boxed answer parsing 🤖🤖🤖

### DIFF
--- a/evaluation/benchmarks/aime25/calculate_metrics.py
+++ b/evaluation/benchmarks/aime25/calculate_metrics.py
@@ -3,12 +3,11 @@
 
 import pandas as pd
 
+from ..utils import extract_boxed as _extract_boxed
+
 
 def extract_boxed(pred_answer):
-    try:
-        return str(pred_answer.split("boxed{")[-1].split("}")[0])
-    except IndexError:
-        return None
+    return _extract_boxed(pred_answer, last=True)
 
 
 def score_aime(pred_answer, true_answer):

--- a/evaluation/benchmarks/math500/calculate_metrics.py
+++ b/evaluation/benchmarks/math500/calculate_metrics.py
@@ -3,12 +3,11 @@
 
 import pandas as pd
 
+from ..utils import extract_boxed as _extract_boxed
+
 
 def extract_boxed(pred_answer):
-    try:
-        return str(pred_answer.split("boxed{")[1].split("}")[0])
-    except IndexError:
-        return None
+    return _extract_boxed(pred_answer)
 
 
 def score_aime(pred_answer, true_answer):

--- a/evaluation/benchmarks/utils.py
+++ b/evaluation/benchmarks/utils.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 1993-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
+def extract_boxed(text: str, *, last: bool = False) -> str | None:
+    marker = "boxed{"
+    marker_index = text.rfind(marker) if last else text.find(marker)
+    if marker_index == -1:
+        return None
+
+    content_start = marker_index + len(marker)
+    depth = 1
+    for index in range(content_start, len(text)):
+        if text[index] == "{":
+            depth += 1
+        elif text[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return text[content_start:index]
+    return None

--- a/tests/test_evaluation_utils.py
+++ b/tests/test_evaluation_utils.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 1993-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
+import unittest
+
+from evaluation.benchmarks.utils import extract_boxed
+
+
+class ExtractBoxedTest(unittest.TestCase):
+    def test_extracts_nested_latex(self):
+        self.assertEqual(extract_boxed(r"Answer: \boxed{\frac{1}{2}}"), r"\frac{1}{2}")
+
+    def test_selects_first_or_last_answer(self):
+        text = r"Draft: \boxed{1}. Final: \boxed{2}."
+        self.assertEqual(extract_boxed(text), "1")
+        self.assertEqual(extract_boxed(text, last=True), "2")
+
+    def test_returns_none_without_complete_box(self):
+        self.assertIsNone(extract_boxed("No boxed answer"))
+        self.assertIsNone(extract_boxed(r"Incomplete: \boxed{\frac{1}{2}"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## PR description

AIME25 and Math500 currently extract a boxed answer by splitting at the first closing brace. Nested LaTeX such as `\boxed{\frac{1}{2}}` is therefore truncated to `\frac{1`, causing a correct model answer to be scored as incorrect.

Add a shared balanced-brace parser and use it in both benchmarks. AIME25 keeps its existing behavior of selecting the last boxed answer, while Math500 continues to select the first. The focused tests cover nested LaTeX, first/last selection, missing answers, and unmatched braces.

Local verification:

```bash
python -m unittest tests/test_evaluation_utils.py
python -m compileall -q evaluation/benchmarks/utils.py evaluation/benchmarks/aime25/calculate_metrics.py evaluation/benchmarks/math500/calculate_metrics.py tests/test_evaluation_utils.py
git diff --check
```

The three focused tests pass. The full test suite and `make style` were not run because this minimal environment intentionally did not install PyTorch, Transformers, datasets, or the development toolchain.

AI assistance: Codex helped inspect the repository, draft the focused implementation, and prepare the tests. I reviewed every changed line and verified the behavior and remote diff.

## Checklist

Before submitting a PR, please make sure:

- [ ] Tests are working (`make test`)
- [ ] Code is formatted correctly (`make style`, on errors try fix with `make format`)
- [x] Copyright header is included
- [x] All commits are signed-off using `git commit -s`

- [ ] (new press) `mypress_press.py` is in the `presses` directory (not applicable)
- [ ] (new press) `MyPress` is in `__init__.py` (not applicable)
- [ ] (new press) `README.md` is updated with a 1 liner about the new press in the Available presses section (not applicable)
- [ ] (new press) New press is in the `default_presses` list in `tests/default_presses.py` (not applicable)
- [ ] (new press) A docstring is provided that follows the same structure as the existing ones (not applicable)

🤖🤖🤖
