### PR TITLE
docs: fix broken `KVzapPress` source link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Several presses inherit from `ScorerPress` ([source](kvpress/presses/scorer_pres
 - `LeverageScorePress` ([source](kvpress/presses/leverage_press.py), [paper](https://arxiv.org/abs/2507.08143)): evict tokens based on approximate statistical leverage (i.e we preserve outliers in the key space).
 - `CompactorPress` ([source](kvpress/presses/compactor_press.py), [paper](https://arxiv.org/abs/2507.08143)): blend `NonCausalAttnPress` and `LeverageScorePress` based on the compression_ratio.
 - `CURPress` ([source](kvpress/presses/cur_press.py), [paper](https://arxiv.org/abs/2509.15038)): prune keys and values based on the CUR decomposition using approximate leverage scores.
-- `KVzapPress` ([source](kvpress/presses/kvzap/kvzap_press.py), [paper](https://arxiv.org/abs/2601.07891), [training](kvzap)): approximate KVzip+ using a fast surrogate model. To be used in conjunction with the `DMSPress`.
+- `KVzapPress` ([source](kvpress/presses/kvzap_press.py), [paper](https://arxiv.org/abs/2601.07891), [training](kvzap)): approximate KVzip+ using a fast surrogate model. To be used in conjunction with the `DMSPress`.
 - `FastKVzipPress` ([source](kvpress/presses/fastkvzip_press.py), [paper](https://arxiv.org/abs/2601.17668)): approximate KVzip through a lightweight gating mechanism.
 - `CapPress` ([source](kvpress/presses/cap_press.py), [paper](https://arxiv.org/abs/2604.25975)): evict tokens based on query-aware capacity scores from a log-determinant leverage proxy.
 


### PR DESCRIPTION
The `KVzapPress` entry in the presses list links its source to `kvpress/presses/kvzap/kvzap_press.py`:

```
- `KVzapPress` ([source](kvpress/presses/kvzap/kvzap_press.py), ...)
```

But there is no `kvpress/presses/kvzap/` subdirectory — the file lives at **`kvpress/presses/kvzap_press.py`** (`class KVzapPress`), exactly like every other press in that list (`kvpress/presses/<name>_press.py`). So the link 404s on GitHub. This drops the extra `kvzap/` path segment. Docs-only, one link. Signed off per DCO.