### PR TITLE
Harden unsafe deserialization paths

### DIFF
--- a/evaluation/benchmarks/loogle/calculate_metrics.py
+++ b/evaluation/benchmarks/loogle/calculate_metrics.py
@@ -2,14 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
+import ast
+
 import nltk
 import pandas as pd
 from bert_score import score
 from nltk.translate.bleu_score import sentence_bleu
 from nltk.translate.meteor_score import single_meteor_score
 from rouge import Rouge
-
-print("WARNING: LooGLE evaluation uses eval(). Only run this script with trusted inputs.")
 
 
 # Code below is adapted from https://github.com/bigai-nlco/LooGLE/blob/main/Evaluation/automatic_metrics.py
@@ -41,9 +41,9 @@ def get_meteor_score(reference, hypothesis):
 
 def get_exact_match(reference, hypothesis):
     try:
-        reference = eval(reference)
+        reference = ast.literal_eval(reference)
         count = len(reference)
-        hypothesis = eval(hypothesis)
+        hypothesis = ast.literal_eval(hypothesis)
         assert isinstance(hypothesis, dict)
     except Exception:
         return 0, 1
@@ -56,10 +56,10 @@ def get_exact_match(reference, hypothesis):
 
 
 def get_partial_match(reference, hypothesis):
-    reference = eval(reference)
+    reference = ast.literal_eval(reference)
     count = len(reference)
     try:
-        hypothesis = eval(hypothesis)
+        hypothesis = ast.literal_eval(hypothesis)
         assert isinstance(hypothesis, dict)
         partial_score_count = 0
         for key in reference:

--- a/kvpress/presses/fastkvzip_press.py
+++ b/kvpress/presses/fastkvzip_press.py
@@ -9,6 +9,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import Generator
 
+import numpy as np
 import torch
 from huggingface_hub import hf_hub_download
 from torch import nn
@@ -123,8 +124,16 @@ def get_gate_weight(model_name: str):
     gate_id = get_gate_id(model_name)
     file_path = hf_hub_download(repo_id="Jang-Hyun/Fast-KVzip", filename=gate_id, repo_type="model")
 
-    # Load the PyTorch tensor/dictionary
-    weights = torch.load(file_path, weights_only=False)["module"]
+    with torch.serialization.safe_globals(
+        [
+            (np._core.multiarray._reconstruct, "numpy.core.multiarray._reconstruct"),
+            np.ndarray,
+            np.dtype,
+            np.dtypes.Float64DType,
+            np.dtypes.Float32DType,
+        ]
+    ):
+        weights = torch.load(file_path, weights_only=True)["module"]
     return weights, gate_id
 
 

--- a/kvpress/presses/fastkvzip_press.py
+++ b/kvpress/presses/fastkvzip_press.py
@@ -126,7 +126,10 @@ def get_gate_weight(model_name: str):
 
     with torch.serialization.safe_globals(
         [
-            (np._core.multiarray._reconstruct, "numpy.core.multiarray._reconstruct"),
+            (
+                np._core.multiarray._reconstruct,  # type: ignore[attr-defined]
+                "numpy.core.multiarray._reconstruct",
+            ),
             np.ndarray,
             np.dtype,
             np.dtypes.Float64DType,


### PR DESCRIPTION
- Replace LooGLE’s eval() with ast.literal_eval().
- Load FastKVzip checkpoints with weights_only=True and restricted NumPy globals.