### PR TITLE
Fix PyramidKVPress.get_layer_budget underflow and divide-by-zero

### DIFF
--- a/kvpress/presses/pyramidkv_press.py
+++ b/kvpress/presses/pyramidkv_press.py
@@ -77,10 +77,12 @@ class PyramidKVPress(SnapKVPress):
             min_num = (max_capacity_prompt - self.window_size) * 2 - max_num
 
         if not (q_len >= max_num >= min_num >= self.window_size):
-            # Fall back to SnapKV
-            return round(q_len * (1 - self.compression_ratio))
+            # Fall back to SnapKV, floored to 1 so a short context never empties the cache
+            return max(1, round(q_len * (1 - self.compression_ratio)))
 
-        steps = (max_num - min_num) / (module.config.num_hidden_layers - 1)
+        # layer_idx is always 0 when num_hidden_layers == 1, so steps is unused there
+        num_hidden_layers = module.config.num_hidden_layers
+        steps = (max_num - min_num) / (num_hidden_layers - 1) if num_hidden_layers > 1 else 0.0
         return round(max_num - module.layer_idx * steps)
 
     def compress(

--- a/tests/presses/test_pyramidkv_press.py
+++ b/tests/presses/test_pyramidkv_press.py
@@ -47,3 +47,20 @@ def test_mean_layer_budget(layer_budget_func, num_hidden_layers, compression_rat
 
     mean_n_kept = total_n_kept / num_hidden_layers
     assert mean_n_kept == pytest.approx(q_len * (1 - compression_ratio), rel=1e-3)
+
+
+def test_get_layer_budget_fallback_floors_to_one():
+    # A short context with a high compression ratio fails the pyramid-shape guard and falls
+    # back to the SnapKV formula, which must never floor to 0 (that would empty the cache).
+    press = PyramidKVPress()
+    press.compression_ratio = 0.96
+    module = MockModule(MockConfig(32), layer_idx=0)
+    assert press.get_layer_budget(module, q_len=10) >= 1
+
+
+def test_get_layer_budget_single_layer_no_division_by_zero():
+    press = PyramidKVPress()
+    press.compression_ratio = 0.5
+    module = MockModule(MockConfig(num_hidden_layers=1), layer_idx=0)
+    n_kept = press.get_layer_budget(module, q_len=4096)
+    assert n_kept >= 1


### PR DESCRIPTION
## PR description

Fixes #265

`PyramidKVPress.get_layer_budget` (`kvpress/presses/pyramidkv_press.py:79-84`) has two independent numerical bugs in its fallback path.

1. When the pyramid-shape guard fails, the code falls back to `round(q_len * (1 - self.compression_ratio))` with no floor. On a short context with a high compression ratio this rounds to 0, so `compress()` calls `scores.topk(0)` and silently empties that layer's KV cache, no error raised. Same silent-eviction family as #227, and the `max(1, ...)` floor #264 already applies to `ScorerPress` and its wrapper presses, but `pyramidkv_press.py` has its own fallback and was not covered by that sweep.
2. `steps = (max_num - min_num) / (module.config.num_hidden_layers - 1)` raises `ZeroDivisionError` whenever the model config reports a single hidden layer.

Filed as #265 with the reproduction (pure arithmetic against the real `get_layer_budget`, no model needed).

The fix floors the fallback to 1 and guards the division: with a single layer `layer_idx` is always 0, so `steps` is never read, and it is set to `0.0` instead of raising.

## Testing

- `tests/presses/test_pyramidkv_press.py::test_get_layer_budget_fallback_floors_to_one` and `::test_get_layer_budget_single_layer_no_division_by_zero`: fail on `main` (assertion failure and `ZeroDivisionError` respectively), pass on this branch.
- Full `tests/presses/test_pyramidkv_press.py`: 212 passed.
- `flake8`, `black --check`, `isort --check-only` on the changed files: clean.
- Not verified: an end-to-end generation run with a real single-layer model; the change only touches the layer-budget arithmetic and is covered at the unit level, matching how this function is already tested in this file.

## Checklist

- [x] Tests are working (`make test`, run on the changed file's own test suite; the full GPU suite was not run, see above)
- [x] Code is formatted correctly (`make style`, run for flake8/black/isort/SPDX on the changed files; `mypy` shows 2 pre-existing errors in files this PR does not touch)
- [x] Copyright header is included
- [x] All commits are signed-off using `git commit -s`