### PR TITLE
Fix KVzap checkpoint loading 

### DIFF
--- a/kvpress/presses/kvzap_press.py
+++ b/kvpress/presses/kvzap_press.py
@@ -13,6 +13,7 @@ from kvpress.presses.scorer_press import ScorerPress
 
 class KVzapConfig(PretrainedConfig):
     model_type = "kvzap"
+    has_no_defaults_at_init = True
 
     def __init__(self, *, input_dim: int, output_dim: int, n_modules: int, hidden_dim: Optional[int] = None, **kwargs):
         super().__init__(**kwargs)


### PR DESCRIPTION
Fixes #267 by marking `KVzapConfig` as requiring initialization arguments. This prevents Transformers 5.x from instantiating the config without dimensions while loading checkpoints. Checked with both transformers 4.56 and 5.16