### PR TITLE
Fix nested boxed answer parsing 2.0

### DIFF
--- a/evaluation/benchmarks/aime25/calculate_metrics.py
+++ b/evaluation/benchmarks/aime25/calculate_metrics.py
@@ -1,18 +1,13 @@
-# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 1993-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import pandas as pd
 
-
-def extract_boxed(pred_answer):
-    try:
-        return str(pred_answer.split("boxed{")[-1].split("}")[0])
-    except IndexError:
-        return None
+from ..utils import extract_boxed
 
 
 def score_aime(pred_answer, true_answer):
-    return extract_boxed(pred_answer) == str(true_answer)
+    return extract_boxed(pred_answer, last=True) == str(true_answer)
 
 
 def calculate_metrics(df: pd.DataFrame) -> dict:

--- a/evaluation/benchmarks/math500/calculate_metrics.py
+++ b/evaluation/benchmarks/math500/calculate_metrics.py
@@ -1,14 +1,9 @@
-# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 1993-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import pandas as pd
 
-
-def extract_boxed(pred_answer):
-    try:
-        return str(pred_answer.split("boxed{")[1].split("}")[0])
-    except IndexError:
-        return None
+from ..utils import extract_boxed
 
 
 def score_aime(pred_answer, true_answer):

--- a/evaluation/benchmarks/utils.py
+++ b/evaluation/benchmarks/utils.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 1993-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
+def extract_boxed(text: str, *, last: bool = False) -> str | None:
+    marker = "boxed{"
+    marker_index = text.rfind(marker) if last else text.find(marker)
+    if marker_index == -1:
+        return None
+
+    content_start = marker_index + len(marker)
+    depth = 1
+    for index in range(content_start, len(text)):
+        if text[index] == "{":
+            depth += 1
+        elif text[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return text[content_start:index]
+
+    return None

--- a/tests/test_evaluation_utils.py
+++ b/tests/test_evaluation_utils.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 1993-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from evaluation.benchmarks.aime25.calculate_metrics import score_aime as score_aime25
+from evaluation.benchmarks.math500.calculate_metrics import score_aime as score_math500
+from evaluation.benchmarks.utils import extract_boxed
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        (r"Answer: \boxed{\frac{1}{2}}", r"\frac{1}{2}"),
+        (r"Answer: \boxed{\left\{x \mid x > 0\right\}}", r"\left\{x \mid x > 0\right\}"),
+    ],
+)
+def test_extract_boxed_handles_nested_latex(text, expected):
+    assert extract_boxed(text) == expected
+
+
+def test_extract_boxed_selects_first_or_last_answer():
+    text = r"Draft: \boxed{1}. Final: \boxed{2}."
+
+    assert extract_boxed(text) == "1"
+    assert extract_boxed(text, last=True) == "2"
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "No boxed answer",
+        r"Incomplete: \boxed{\frac{1}{2}",
+    ],
+)
+def test_extract_boxed_returns_none_without_complete_box(text):
+    assert extract_boxed(text) is None
+
+
+def test_aime25_scores_last_boxed_answer():
+    assert score_aime25(r"Draft: \boxed{1}. Final: \boxed{\frac{1}{2}}.", r"\frac{1}{2}")
+
+
+def test_math500_scores_first_boxed_answer():
+    assert score_math500(r"First: \boxed{\frac{1}{2}}. Later: \boxed{1}.", r"\frac{1}{2}")


### PR DESCRIPTION
## PR description

Builds on top of #254 and adds some fixes. 

## Checklist

- [x] Tests are working (`make test`)
- [x] Code is formatted correctly (`make style`, on errors try fix with `make format`)
- [x] Copyright header is included
- [x] All commits are signed-off  using `git commit -s`

- [ ] (new press) `mypress_press.py` is in the `presses` directory
- [ ] (new press) `MyPress` is in `__init__.py` 
- [ ] (new press) `README.md` is updated with a 1 liner about the new press in the Available presses section
- [ ] (new press) New press is in the `default_presses` list in `tests/default_presses.py`
- [ ] (new press) A docstring is provided that follows the same structure as the existing ones
