### PR TITLE
Harden evaluation against remote code execution 🤖🤖🤖

### DIFF
--- a/evaluation/benchmarks/loogle/create_huggingface_dataset.py
+++ b/evaluation/benchmarks/loogle/create_huggingface_dataset.py
@@ -4,7 +4,6 @@
 
 import json
 
-import pandas as pd
 from datasets import Dataset, load_dataset
 
 # Templates based on https://github.com/bigai-nlco/LooGLE/blob/main/config/task2prompt.json

--- a/evaluation/benchmarks/loogle/create_huggingface_dataset.py
+++ b/evaluation/benchmarks/loogle/create_huggingface_dataset.py
@@ -34,18 +34,15 @@ max_new_tokens = {"shortdep_qa": 300, "longdep_qa": 500, "longdep_summarization"
 
 for task in ["shortdep_qa", "longdep_qa", "shortdep_cloze", "longdep_summarization"]:
 
-    df = load_dataset("bigainlco/LooGLE", task, split="test", trust_remote_code=True).to_pandas()
+    source_task = "summarization" if task == "longdep_summarization" else task
+    df = load_dataset("bigainlco/LooGLE", source_task, split="test").to_pandas()
 
-    if task == "longdep_summarization":
-        df["question"] = ""
-        df = df.rename(columns={"output": "answer", "input": "context"})
-    else:
-        df["qa_pairs"] = df["qa_pairs"].apply(lambda x: eval(x) if x != "none" else [{"Q": "", "A": "", "S": [""]}])
-        df = df.explode("qa_pairs")
-        df = pd.concat([df.drop(["qa_pairs"], axis=1), df["qa_pairs"].apply(pd.Series)], axis=1)
-        df = df.rename(columns={"A": "answer", "Q": "question", "input": "context"})
-        if task == "shortdep_cloze":
-            df["answer"] = df["answer"].apply(json.dumps, ensure_ascii=False)
+    if task == "shortdep_cloze":
+        df["answer"] = df["answer"].apply(
+            lambda values: json.dumps(
+                {f"<mask-{i}>": value for i, value in enumerate(values)}, ensure_ascii=False
+            )
+        )
 
     df["context"] = df["context"].apply(lambda x: context_prompt[task].format(input=x))
     df["question"] = df["question"].apply(lambda x: question_prompt[task].format(Q=x))

--- a/evaluation/evaluate.py
+++ b/evaluation/evaluate.py
@@ -386,7 +386,7 @@ class EvaluationRunner:
                 pass
 
         logger.info(f"Loading model pipeline for: {model_name} on device: {device} with model_kwargs: {model_kwargs}")
-        pipeline_kwargs = {
+        pipeline_kwargs: Dict[str, Any] = {
             "model": model_name,
             "model_kwargs": model_kwargs,
         }

--- a/evaluation/evaluate.py
+++ b/evaluation/evaluate.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 1993-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import json
@@ -67,6 +67,7 @@ class EvaluationConfig:
 
     # Model-specific parameters
     model_kwargs: Optional[Dict[str, Any]] = None
+    trust_remote_code: bool = False
 
     # Press information (will be set after press setup)
     press_init_command: Optional[str] = None
@@ -388,8 +389,12 @@ class EvaluationRunner:
         pipeline_kwargs = {
             "model": model_name,
             "model_kwargs": model_kwargs,
-            "trust_remote_code": True,
         }
+        if self.config.trust_remote_code:
+            logger.warning(
+                "trust_remote_code=True: the model repository can execute arbitrary Python code during loading."
+            )
+            pipeline_kwargs["trust_remote_code"] = True
         if device == "auto":
             pipeline_kwargs["device_map"] = "auto"
         else:

--- a/evaluation/evaluate_config.yaml
+++ b/evaluation/evaluate_config.yaml
@@ -4,6 +4,7 @@
 output_dir: "./results"
 
 model: "meta-llama/Meta-Llama-3.1-8B-Instruct"
+trust_remote_code: false                         # Explicitly opt in only for trusted model repositories
 dataset: "ruler"                                  # see DATASET_REGISTRY in evaluate_registry.py
 data_dir: "4096"                                  # Subdirectory of the dataset (if applicable) else leave "null"
 


### PR DESCRIPTION
- `trust_remote_code` now defaults to False in evaluation 
- removed `eval` from Loogle dataset parsing and updated it since the remote dataset changed