### PR TITLE
Fix random scoring device and dtype mismatches 🤖🤖🤖

### DIFF
--- a/kvpress/presses/cur_press.py
+++ b/kvpress/presses/cur_press.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 1993-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import math
@@ -35,7 +35,7 @@ class CURPress(ScorerPress):
 
         if self.use_random_leverage:
             r = 20
-            G = torch.randn(keys.shape[-1], r, device=keys.device) / math.sqrt(r)
+            G = torch.randn(keys.shape[-1], r, device=keys.device, dtype=keys.dtype) / math.sqrt(r)
             keys = keys @ G
             values = values @ G
 

--- a/kvpress/presses/random_press.py
+++ b/kvpress/presses/random_press.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 1993-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 
@@ -41,6 +41,6 @@ class RandomPress(ScorerPress):
     ) -> torch.Tensor:
         generator = None
         if self.seed is not None:
-            generator = torch.Generator()
+            generator = torch.Generator(device=keys.device)
             generator.manual_seed(self.seed)
         return torch.rand(*keys.shape[:-1], generator=generator, device=keys.device, dtype=keys.dtype)


### PR DESCRIPTION
## PR description

`RandomPress(seed=42)` creates a CPU generator even when the KV cache is on a GPU, so scoring raises a generator-device mismatch. `CURPress(use_random_leverage=True)` creates its projection in the default floating dtype, so fp16/bf16 caches raise a matmul dtype mismatch (float64 caches are affected too).

Create RandomPress's private generator on `keys.device`, and create CURPress's shared key/value projection with `keys.dtype`. Seeded calls still restart their private RNG, preserve the existing CPU sequence, and leave global RNG states unchanged. MPS generator support and reproducibility were verified on PyTorch 2.3.1, the declared minimum, and on 2.14.0; no backend fallback is needed for these versions.

The new tests exercise scoring and compression directly without downloading models. On macOS with Python 3.12.12, PyTorch 2.14.0, and transformers 5.2.0:

- Before the fixes: **27 failed, 14 passed, 4 skipped**. Three failures are seeded MPS scoring; 24 are CUR projection dtype mismatches.
- After the fixes: **41 passed, 4 skipped**. CUDA cases are included but skipped locally because CUDA is unavailable. CUR coverage includes fp16/bf16/fp32/fp64, all leverage types, local-window padding, normalization, and attention sinks.
- `make style` passes, including mypy on 83 source files. Changed files pass Black/isort checks and `git diff --check`.

Implemented and validated with OpenAI Codex. No model-quality or CUDA-runtime results are claimed.

## Checklist

- [x] New regression tests pass (`PYTHONPATH=. .venv/bin/pytest -q tests/presses/test_random_press.py tests/presses/test_cur_press.py`).
- [ ] Full `make test` / GPU CI: not run locally; requires CUDA/flash-attn and model fixtures.
- [x] Code is formatted correctly; `make style` passes.
- [x] Copyright headers are included.
- [x] Commit is DCO signed off using `git commit -s`.

New-press checklist items are not applicable.

🤖🤖🤖
