### PR TITLE
fix: complete the n_kept floor sweep deferred in #264

### DIFF
--- a/kvpress/presses/criticalkv_press.py
+++ b/kvpress/presses/criticalkv_press.py
@@ -81,6 +81,10 @@ class CriticalKVPress(ScorerPress):
         scores = self.press.score(module, hidden_states, keys, values, attentions, kwargs)
         k_len = keys.shape[2]
         selection_budget = int((1 - self.compression_ratio) * k_len * self.first_stage_ratio)
+        if self.first_stage_ratio > 0:
+            # Floor to 1 so short contexts never silently skip stage-1 selection; a zero
+            # budget stays zero when the entire cache is evicted by design (ratio >= 1.0).
+            selection_budget = max(1, selection_budget) if self.compression_ratio < 1.0 else 0
         top_k_index = torch.topk(scores, selection_budget, sorted=True, dim=-1).indices
 
         # Stage 2

--- a/kvpress/presses/fastkvzip_press.py
+++ b/kvpress/presses/fastkvzip_press.py
@@ -253,7 +253,9 @@ class FastKVzipPress(BasePress):
 
         ctx_len = scores.size(-1)
         if ctx_len < 32000:
-            window_size = int(ctx_len * self.window_ratio)
+            # max(1, ...) so a short context never yields window_size == 0: the slice
+            # [:, :, -0:] would protect the entire context instead of a local window.
+            window_size = max(1, int(ctx_len * self.window_ratio))
         else:
             window_size = self.window_size
         scores[:, :, -window_size:] = 1.0

--- a/kvpress/presses/kvcompose_press.py
+++ b/kvpress/presses/kvcompose_press.py
@@ -21,6 +21,7 @@ from transformers.models.qwen2.modeling_qwen2 import Qwen2ForCausalLM
 from transformers.models.qwen3.modeling_qwen3 import Qwen3ForCausalLM
 
 from kvpress.presses.base_press import BasePress
+from kvpress.utils import compute_n_kept
 
 logger = logging.getLogger(__name__)
 
@@ -273,16 +274,22 @@ class KVComposePress(BasePress):
         """
         self.compute_composite_scores()
 
-        n_kept = int(self.composite_scores_per_head.numel() * (1 - self.compression_ratio))
+        n_kept = compute_n_kept(self.composite_scores_per_head.numel(), self.compression_ratio)
         kept = self.composite_scores_per_head.reshape(-1).topk(n_kept).indices // self.context_len
         bins = self.num_layers * self.num_kv_heads
         self.important_per_head = (
             torch.bincount(kept, minlength=bins).reshape(self.num_layers, self.num_kv_heads).cpu().numpy()
         )
 
-        n_kept = int(self.composite_scores_per_layer.numel() * (1 - self.compression_ratio))
+        n_kept = compute_n_kept(self.composite_scores_per_layer.numel(), self.compression_ratio)
         kept = self.composite_scores_per_layer.reshape(-1).topk(n_kept).indices // self.context_len
-        self.important_per_layer = torch.bincount(kept, minlength=self.num_layers).cpu().numpy()
+        # While compression_ratio < 1 the caller only compresses partially, so no layer
+        # cache may end up empty: floor every per-layer count, respecting keep_token_lower_bound
+        # when it is stricter than 1.
+        per_layer_floor = max(1, self.keep_token_lower_bound)
+        self.important_per_layer = (
+            torch.bincount(kept, minlength=self.num_layers).clamp(min=per_layer_floor).cpu().numpy()
+        )
 
     def prepare_important_masks(self):
         """

--- a/tests/default_presses.py
+++ b/tests/default_presses.py
@@ -2,14 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np
-import pytest
 import torch
-from transformers import DynamicCache
 
 from kvpress import (
     CapPress,
     CompactorPress,
-    CriticalKVPress,
     CURPress,
     DuoAttentionPress,
     ExpectedAttentionPress,
@@ -36,7 +33,6 @@ from kvpress import (
 )
 from kvpress.presses.fastkvzip_press import FastKVzipGate
 from kvpress.presses.kvzap_press import KVzapConfig, KVzapModel
-from tests.fixtures import unit_test_model  # noqa: F401
 
 
 class TestDuoAttentionPress(DuoAttentionPress):
@@ -101,19 +97,6 @@ class TestRestoreKVPress(RestoreKVPress):
             model.add_adapter(config, adapter_name=self.adapter_name)
         model.disable_adapters()
         self.restore_embeddings = torch.zeros(8, model.config.hidden_size, device=model.device, dtype=model.dtype)
-
-
-class StoreScoresCriticalKVPress(CriticalKVPress):
-    """Records the final scores returned by the real CriticalKVPress.score during compression."""
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.stored_scores = []
-
-    def score(self, module, hidden_states, keys, values, attentions, kwargs):
-        scores = super().score(module, hidden_states, keys, values, attentions, kwargs)
-        self.stored_scores.append(scores)
-        return scores
 
 
 # contains all presses to be tested
@@ -204,94 +187,3 @@ default_presses = [
     {"cls": CapPress, "kwargs": [{"compression_ratio": 0.5}, {"compression_ratio": 0.8}]},
     {"cls": TestLUKVPress, "kwargs": [{"compression_ratio": 0.5}, {"compression_ratio": 0.8}]},
 ]
-
-
-def compress_short_context(press, model, context_len=8, batch_size=1):
-    """Run a single prefill through ``press`` on the unit-test model and return the cache."""
-    with press(model):
-        input_ids = torch.randint(0, 1024, (batch_size, context_len), device=model.device)
-        cache = DynamicCache()
-        model(input_ids, past_key_values=cache)
-    return cache
-
-
-@pytest.mark.parametrize("compression_ratio", [0.95, 0.99])
-def test_kvcompose_structured_never_empties_a_layer_on_short_contexts(unit_test_model, compression_ratio):  # noqa: F811
-    """``int(numel * (1 - compression_ratio))`` floors to 0 on short contexts and ``topk(0)``
-    silently empties every layer cache although the caller only compresses partially."""
-    press = KVComposePress(compression_ratio=compression_ratio)
-    cache = compress_short_context(press, unit_test_model)
-
-    assert cache.get_seq_length() >= 1
-    for layer in cache.layers:
-        assert layer.keys.shape[2] >= 1
-
-
-@pytest.mark.parametrize("compression_ratio", [0.95, 0.99])
-def test_kvcompose_keep_token_lower_bound_survives_on_short_contexts(unit_test_model, compression_ratio):  # noqa: F811
-    """The +1e9 score boost cannot rescue the lower-bound tokens when the global budget floors
-    to 0 (``topk(0)`` drops boosted tokens too), so every layer must keep at least
-    ``keep_token_lower_bound`` tokens."""
-    press = KVComposePress(compression_ratio=compression_ratio, keep_token_lower_bound=2)
-    cache = compress_short_context(press, unit_test_model)
-
-    assert cache.get_seq_length() >= press.keep_token_lower_bound
-    for layer in cache.layers:
-        assert layer.keys.shape[2] >= press.keep_token_lower_bound
-
-
-def test_kvcompose_structured_batch_size_2_does_not_collapse_on_short_contexts(unit_test_model):  # noqa: F811
-    """The same zero budget also collapses a batch of sequences to an empty cache."""
-    press = KVComposePress(compression_ratio=0.95)
-    cache = compress_short_context(press, unit_test_model, batch_size=2)
-
-    assert cache.get_seq_length() >= 1
-    for layer in cache.layers:
-        assert layer.keys.shape[2] >= 1
-
-
-def test_kvcompose_unstructured_keeps_at_least_one_token_on_short_contexts(unit_test_model):  # noqa: F811
-    """Unstructured compression flags evicted tokens via ``masked_key_indices``; with a zero
-    budget every token of every head is flagged for eviction. Per-head zero counts remain
-    legitimate head pruning, but the global budget must still keep at least one token."""
-    context_len = 8
-    press = KVComposePress(structured=False, compression_ratio=0.99)
-    compress_short_context(press, unit_test_model, context_len=context_len)
-
-    config = unit_test_model.config
-    n_masked = sum(len(layer.self_attn.masked_key_indices[2]) for layer in unit_test_model.model.layers)
-    total = config.num_hidden_layers * config.num_key_value_heads * context_len
-    assert n_masked < total
-
-
-@pytest.mark.parametrize("compression_ratio", [0.95, 0.99])
-def test_criticalkv_stage1_selection_boosts_on_short_contexts(unit_test_model, compression_ratio):  # noqa: F811
-    """``int((1 - compression_ratio) * k_len * first_stage_ratio)`` floors to 0 on short contexts
-    and ``topk(scores, 0)`` legally returns nothing, silently skipping stage-1 protection."""
-    press = StoreScoresCriticalKVPress(press=KnormPress(compression_ratio=compression_ratio))
-    compress_short_context(press, unit_test_model)
-
-    assert len(press.stored_scores) == unit_test_model.config.num_hidden_layers
-    for scores in press.stored_scores:
-        boosted = scores == torch.finfo(scores.dtype).max
-        assert boosted.any(dim=-1).all(), "stage-1 selection boosted no position"
-
-
-def test_criticalkv_stage1_selection_disabled_when_first_stage_ratio_is_zero(unit_test_model):  # noqa: F811
-    """``first_stage_ratio=0`` disables stage 1 by design; the floor must not re-enable it."""
-    press = StoreScoresCriticalKVPress(press=KnormPress(compression_ratio=0.95), first_stage_ratio=0.0)
-    compress_short_context(press, unit_test_model)
-
-    for scores in press.stored_scores:
-        assert not (scores == torch.finfo(scores.dtype).max).any()
-
-
-def test_fastkvzip_short_context_window_does_not_protect_everything(unit_test_model):  # noqa: F811
-    """``int(ctx_len * window_ratio)`` floors to 0 on short contexts, and assigning to
-    ``scores[:, :, -0:]`` protects the entire context instead of a local window."""
-    press = TestFastKVzipPress(compression_ratio=0.5)
-    compress_short_context(press, unit_test_model)
-
-    scores = press.score_val  # stacked per-layer scores, shape (n_layers, bsz, heads, ctx_len)
-    assert not (scores == 1.0).all()
-    assert (scores[..., -1] == 1.0).all()

--- a/tests/default_presses.py
+++ b/tests/default_presses.py
@@ -2,11 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np
+import pytest
 import torch
+from transformers import DynamicCache
 
 from kvpress import (
     CapPress,
     CompactorPress,
+    CriticalKVPress,
     CURPress,
     DuoAttentionPress,
     ExpectedAttentionPress,
@@ -33,6 +36,7 @@ from kvpress import (
 )
 from kvpress.presses.fastkvzip_press import FastKVzipGate
 from kvpress.presses.kvzap_press import KVzapConfig, KVzapModel
+from tests.fixtures import unit_test_model  # noqa: F401
 
 
 class TestDuoAttentionPress(DuoAttentionPress):
@@ -97,6 +101,19 @@ class TestRestoreKVPress(RestoreKVPress):
             model.add_adapter(config, adapter_name=self.adapter_name)
         model.disable_adapters()
         self.restore_embeddings = torch.zeros(8, model.config.hidden_size, device=model.device, dtype=model.dtype)
+
+
+class StoreScoresCriticalKVPress(CriticalKVPress):
+    """Records the final scores returned by the real CriticalKVPress.score during compression."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.stored_scores = []
+
+    def score(self, module, hidden_states, keys, values, attentions, kwargs):
+        scores = super().score(module, hidden_states, keys, values, attentions, kwargs)
+        self.stored_scores.append(scores)
+        return scores
 
 
 # contains all presses to be tested
@@ -187,3 +204,94 @@ default_presses = [
     {"cls": CapPress, "kwargs": [{"compression_ratio": 0.5}, {"compression_ratio": 0.8}]},
     {"cls": TestLUKVPress, "kwargs": [{"compression_ratio": 0.5}, {"compression_ratio": 0.8}]},
 ]
+
+
+def compress_short_context(press, model, context_len=8, batch_size=1):
+    """Run a single prefill through ``press`` on the unit-test model and return the cache."""
+    with press(model):
+        input_ids = torch.randint(0, 1024, (batch_size, context_len), device=model.device)
+        cache = DynamicCache()
+        model(input_ids, past_key_values=cache)
+    return cache
+
+
+@pytest.mark.parametrize("compression_ratio", [0.95, 0.99])
+def test_kvcompose_structured_never_empties_a_layer_on_short_contexts(unit_test_model, compression_ratio):  # noqa: F811
+    """``int(numel * (1 - compression_ratio))`` floors to 0 on short contexts and ``topk(0)``
+    silently empties every layer cache although the caller only compresses partially."""
+    press = KVComposePress(compression_ratio=compression_ratio)
+    cache = compress_short_context(press, unit_test_model)
+
+    assert cache.get_seq_length() >= 1
+    for layer in cache.layers:
+        assert layer.keys.shape[2] >= 1
+
+
+@pytest.mark.parametrize("compression_ratio", [0.95, 0.99])
+def test_kvcompose_keep_token_lower_bound_survives_on_short_contexts(unit_test_model, compression_ratio):  # noqa: F811
+    """The +1e9 score boost cannot rescue the lower-bound tokens when the global budget floors
+    to 0 (``topk(0)`` drops boosted tokens too), so every layer must keep at least
+    ``keep_token_lower_bound`` tokens."""
+    press = KVComposePress(compression_ratio=compression_ratio, keep_token_lower_bound=2)
+    cache = compress_short_context(press, unit_test_model)
+
+    assert cache.get_seq_length() >= press.keep_token_lower_bound
+    for layer in cache.layers:
+        assert layer.keys.shape[2] >= press.keep_token_lower_bound
+
+
+def test_kvcompose_structured_batch_size_2_does_not_collapse_on_short_contexts(unit_test_model):  # noqa: F811
+    """The same zero budget also collapses a batch of sequences to an empty cache."""
+    press = KVComposePress(compression_ratio=0.95)
+    cache = compress_short_context(press, unit_test_model, batch_size=2)
+
+    assert cache.get_seq_length() >= 1
+    for layer in cache.layers:
+        assert layer.keys.shape[2] >= 1
+
+
+def test_kvcompose_unstructured_keeps_at_least_one_token_on_short_contexts(unit_test_model):  # noqa: F811
+    """Unstructured compression flags evicted tokens via ``masked_key_indices``; with a zero
+    budget every token of every head is flagged for eviction. Per-head zero counts remain
+    legitimate head pruning, but the global budget must still keep at least one token."""
+    context_len = 8
+    press = KVComposePress(structured=False, compression_ratio=0.99)
+    compress_short_context(press, unit_test_model, context_len=context_len)
+
+    config = unit_test_model.config
+    n_masked = sum(len(layer.self_attn.masked_key_indices[2]) for layer in unit_test_model.model.layers)
+    total = config.num_hidden_layers * config.num_key_value_heads * context_len
+    assert n_masked < total
+
+
+@pytest.mark.parametrize("compression_ratio", [0.95, 0.99])
+def test_criticalkv_stage1_selection_boosts_on_short_contexts(unit_test_model, compression_ratio):  # noqa: F811
+    """``int((1 - compression_ratio) * k_len * first_stage_ratio)`` floors to 0 on short contexts
+    and ``topk(scores, 0)`` legally returns nothing, silently skipping stage-1 protection."""
+    press = StoreScoresCriticalKVPress(press=KnormPress(compression_ratio=compression_ratio))
+    compress_short_context(press, unit_test_model)
+
+    assert len(press.stored_scores) == unit_test_model.config.num_hidden_layers
+    for scores in press.stored_scores:
+        boosted = scores == torch.finfo(scores.dtype).max
+        assert boosted.any(dim=-1).all(), "stage-1 selection boosted no position"
+
+
+def test_criticalkv_stage1_selection_disabled_when_first_stage_ratio_is_zero(unit_test_model):  # noqa: F811
+    """``first_stage_ratio=0`` disables stage 1 by design; the floor must not re-enable it."""
+    press = StoreScoresCriticalKVPress(press=KnormPress(compression_ratio=0.95), first_stage_ratio=0.0)
+    compress_short_context(press, unit_test_model)
+
+    for scores in press.stored_scores:
+        assert not (scores == torch.finfo(scores.dtype).max).any()
+
+
+def test_fastkvzip_short_context_window_does_not_protect_everything(unit_test_model):  # noqa: F811
+    """``int(ctx_len * window_ratio)`` floors to 0 on short contexts, and assigning to
+    ``scores[:, :, -0:]`` protects the entire context instead of a local window."""
+    press = TestFastKVzipPress(compression_ratio=0.5)
+    compress_short_context(press, unit_test_model)
+
+    scores = press.score_val  # stacked per-layer scores, shape (n_layers, bsz, heads, ctx_len)
+    assert not (scores == 1.0).all()
+    assert (scores[..., -1] == 1.0).all()

--- a/tests/presses/test_budget_floor_sweep.py
+++ b/tests/presses/test_budget_floor_sweep.py
@@ -1,0 +1,149 @@
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for the budget floor sweep deferred by #264.
+
+Three budget derivations still floor to zero on short contexts, silently
+breaking partial compression:
+
+* ``KVComposePress`` computed ``int(numel * (1 - compression_ratio))``, so a
+  ratio close to 1.0 yields ``topk(0)`` and empties the whole cache (or a
+  single layer's cache after the global budget distribution) although the
+  caller only compresses partially.
+* ``CriticalKVPress`` computed ``int((1 - ratio) * k_len * first_stage_ratio)``
+  which is 0 on short contexts, so ``topk(scores, 0)`` silently skips the
+  stage-1 selection.
+* ``FastKVzipPress`` computed ``int(ctx_len * window_ratio)`` which is 0 on
+  short contexts, and assigning to ``scores[:, :, -0:]`` protects the entire
+  context instead of a local window.
+
+The tests below drive the real presses on the unit-test model (no mocks of the
+code under test) with degenerate ratios close to 1.0 on short contexts.
+"""
+
+import pytest
+import torch
+from transformers import DynamicCache
+
+from kvpress import CriticalKVPress, FastKVzipPress, KnormPress, KVComposePress
+from kvpress.presses.fastkvzip_press import FastKVzipGate
+from tests.fixtures import unit_test_model  # noqa: F401
+
+
+class MockGatesFastKVzipPress(FastKVzipPress):
+    """Test version of FastKVzipPress that creates a mock gate instead of loading from HuggingFace."""
+
+    def post_init_from_model(self, model):
+        if self.gates is None:
+            dtype = model.config.dtype
+            input_dim = model.config.hidden_size
+            ngroup = model.config.num_attention_heads // model.config.num_key_value_heads
+            nhead = model.config.num_key_value_heads
+
+            self.gates = []
+            for idx in range(model.config.num_hidden_layers):
+                module = FastKVzipGate(idx, input_dim, nhead, ngroup, dtype).to(model.device)
+                self.gates.append(module)
+
+
+class StoreScoresCriticalKVPress(CriticalKVPress):
+    """Records the final scores returned by the real CriticalKVPress.score during compression."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.stored_scores = []
+
+    def score(self, module, hidden_states, keys, values, attentions, kwargs):
+        scores = super().score(module, hidden_states, keys, values, attentions, kwargs)
+        self.stored_scores.append(scores)
+        return scores
+
+
+def compress_short_context(press, model, context_len=8, batch_size=1):
+    """Run a single prefill through ``press`` on the unit-test model and return the cache."""
+    with press(model):
+        input_ids = torch.randint(0, 1024, (batch_size, context_len), device=model.device)
+        cache = DynamicCache()
+        model(input_ids, past_key_values=cache)
+    return cache
+
+
+@pytest.mark.parametrize("compression_ratio", [0.95, 0.99])
+def test_kvcompose_structured_never_empties_a_layer_on_short_contexts(unit_test_model, compression_ratio):  # noqa: F811
+    """``int(numel * (1 - compression_ratio))`` floors to 0 on short contexts and ``topk(0)``
+    silently empties every layer cache although the caller only compresses partially."""
+    press = KVComposePress(compression_ratio=compression_ratio)
+    cache = compress_short_context(press, unit_test_model)
+
+    assert cache.get_seq_length() >= 1
+    for layer in cache.layers:
+        assert layer.keys.shape[2] >= 1
+
+
+@pytest.mark.parametrize("compression_ratio", [0.95, 0.99])
+def test_kvcompose_keep_token_lower_bound_survives_on_short_contexts(unit_test_model, compression_ratio):  # noqa: F811
+    """The +1e9 score boost cannot rescue the lower-bound tokens when the global budget floors
+    to 0 (``topk(0)`` drops boosted tokens too), so every layer must keep at least
+    ``keep_token_lower_bound`` tokens."""
+    press = KVComposePress(compression_ratio=compression_ratio, keep_token_lower_bound=2)
+    cache = compress_short_context(press, unit_test_model)
+
+    assert cache.get_seq_length() >= press.keep_token_lower_bound
+    for layer in cache.layers:
+        assert layer.keys.shape[2] >= press.keep_token_lower_bound
+
+
+def test_kvcompose_structured_batch_size_2_does_not_collapse_on_short_contexts(unit_test_model):  # noqa: F811
+    """The same zero budget also collapses a batch of sequences to an empty cache."""
+    press = KVComposePress(compression_ratio=0.95)
+    cache = compress_short_context(press, unit_test_model, batch_size=2)
+
+    assert cache.get_seq_length() >= 1
+    for layer in cache.layers:
+        assert layer.keys.shape[2] >= 1
+
+
+def test_kvcompose_unstructured_keeps_at_least_one_token_on_short_contexts(unit_test_model):  # noqa: F811
+    """Unstructured compression flags evicted tokens via ``masked_key_indices``; with a zero
+    budget every token of every head is flagged for eviction. Per-head zero counts remain
+    legitimate head pruning, but the global budget must still keep at least one token."""
+    context_len = 8
+    press = KVComposePress(structured=False, compression_ratio=0.99)
+    compress_short_context(press, unit_test_model, context_len=context_len)
+
+    config = unit_test_model.config
+    n_masked = sum(len(layer.self_attn.masked_key_indices[2]) for layer in unit_test_model.model.layers)
+    total = config.num_hidden_layers * config.num_key_value_heads * context_len
+    assert n_masked < total
+
+
+@pytest.mark.parametrize("compression_ratio", [0.95, 0.99])
+def test_criticalkv_stage1_selection_boosts_on_short_contexts(unit_test_model, compression_ratio):  # noqa: F811
+    """``int((1 - compression_ratio) * k_len * first_stage_ratio)`` floors to 0 on short contexts
+    and ``topk(scores, 0)`` legally returns nothing, silently skipping stage-1 protection."""
+    press = StoreScoresCriticalKVPress(press=KnormPress(compression_ratio=compression_ratio))
+    compress_short_context(press, unit_test_model)
+
+    assert len(press.stored_scores) == unit_test_model.config.num_hidden_layers
+    for scores in press.stored_scores:
+        boosted = scores == torch.finfo(scores.dtype).max
+        assert boosted.any(dim=-1).all(), "stage-1 selection boosted no position"
+
+
+def test_criticalkv_stage1_selection_disabled_when_first_stage_ratio_is_zero(unit_test_model):  # noqa: F811
+    """``first_stage_ratio=0`` disables stage 1 by design; the floor must not re-enable it."""
+    press = StoreScoresCriticalKVPress(press=KnormPress(compression_ratio=0.95), first_stage_ratio=0.0)
+    compress_short_context(press, unit_test_model)
+
+    for scores in press.stored_scores:
+        assert not (scores == torch.finfo(scores.dtype).max).any()
+
+
+def test_fastkvzip_short_context_window_does_not_protect_everything(unit_test_model):  # noqa: F811
+    """``int(ctx_len * window_ratio)`` floors to 0 on short contexts, and assigning to
+    ``scores[:, :, -0:]`` protects the entire context instead of a local window."""
+    press = MockGatesFastKVzipPress(compression_ratio=0.5)
+    compress_short_context(press, unit_test_model)
+
+    scores = press.score_val  # stacked per-layer scores, shape (n_layers, bsz, heads, ctx_len)
+    assert not (scores == 1.0).all()
+    assert (scores[..., -1] == 1.0).all()


### PR DESCRIPTION
## PR description

#264 introduced `compute_n_kept` (`kvpress/utils.py`) — 0 by design at `compression_ratio >= 1.0`, else `max(1, int(...))` — and applied it to the `k_len`-form budget sites, but deferred the remaining budget derivations. Three unguarded sites survive on `main`, each silently misbehaving on short contexts with no error raised:

| file:line | budget form | degenerate failure (probed on `MaxJeblick/llama2-0b-unit-test`, ctx=8) |
|---|---|---|
| `kvpress/presses/kvcompose_press.py:277,284` | `int(numel * (1 - compression_ratio))` (numel form) | floors to 0 → `topk(0)` **silently empties the whole cache** (structured form, ratio 0.95: `cache.get_seq_length()=0`, `keys=(1,2,0,6)`); even `keep_token_lower_bound`-boosted tokens (+1e9) are dropped by `topk(0)` |
| `kvpress/presses/criticalkv_press.py:83` | `int((1 - ratio) * k_len * first_stage_ratio)` | floors to 0 → `topk(scores, 0)` is legal → **stage-1 protection silently skipped** (0 positions boosted to `finfo.max`) |
| `kvpress/presses/fastkvzip_press.py:256` | `window_size = int(ctx_len * window_ratio)` | floors to 0 → `scores[:, :, -0:] = 1.0` sets **all** scores to 1.0 (the `-0:` slice is the whole tensor) → full-protection inversion on any context shorter than `1/window_ratio` (50 tokens at the default 0.02) |

Additionally, on the kvcompose structured path the per-layer distribution of the global budget can still leave a layer at 0 even after the global floor (probed: per-layer `[1, 0]` at ratio 0.99 — one layer's cache empties while `compression_ratio < 1.0`).

This PR completes the sweep:

- **kvcompose**: both numel forms route through `compute_n_kept`; the structured per-layer counts are clamped to `max(1, keep_token_lower_bound)` so no layer empties while `compression_ratio < 1.0` (per-head zeros are left alone — head pruning is a legitimate outcome there).
- **criticalkv**: `selection_budget` gets a floor **only when `first_stage_ratio > 0` and `compression_ratio < 1.0`** (mirroring the `n_safe` guard shape from the #264 review; `first_stage_ratio = 0` means stage 1 is disabled by design and must stay at 0).
- **fastkvzip**: `window_size = max(1, int(ctx_len * self.window_ratio))`.

The change is purely additive: every floor only activates when the derived budget is 0. Verified byte-identical behaviour at normal ratios (kvcompose/criticalkv/fastkvzip at 0.5 and 0.8, ctx=128, fixed seed) — the clamp is inactive whenever the budget covers the layers. `compression_ratio >= 1.0` still means "evict everything" everywhere (`compute_n_kept` contract). The guarded sites from #264 and the hand-rolled `chunk`/`pyramidkv` floors are untouched.

## Tests

`tests/presses/test_budget_floor_sweep.py` (10 cases, all on the real presses via the unit-test model, no mocks of the fixed code):

- kvcompose structured form never empties a layer at ratio 0.95 / 0.99 (every layer keeps >= 1 token), including `bsz=2`
- `keep_token_lower_bound` tokens survive at ratio 0.95 / 0.99 (per-layer >= lower bound)
- unstructured form keeps >= 1 token globally at ratio 0.98
- criticalkv boosts >= 1 position when `first_stage_ratio > 0` (ratio 0.95 / 0.99), and stays at 0 when `first_stage_ratio = 0` (design behavior, green on `main` too)
- fastkvzip short-context scores are not all 1.0

The 9 degenerate cases are red on `main` (emptying / skipping / flattening) and green with this change. Full `tests/presses/` passes (529 passed; the one `test_ea_with_stats.py::test_load_stats` failure is a pre-existing gated-repo download error, identical on `main`).

## Checklist

- [x] Tests are working (`make test`) — `tests/presses/` 529 passed / 4 skipped; the single `test_ea_with_stats.py::test_load_stats` failure is a pre-existing gated-repo download error that fails identically on `main` (verified in a clean checkout)
- [x] Code is formatted correctly (`make style`) — flake8 clean, mypy clean (83 files); note `black`/`isort` report pre-existing drift on `kvcompose_press.py` that is identical on `main` (verified) and untouched by this PR
- [x] Copyright header is included (SPDX on the new test file)
- [x] All commits are signed-off using `git commit -s`